### PR TITLE
Add discovery steps to legacy adoption pipeline

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -60,6 +60,23 @@
       "description": "Find legacy memory files (no beacons / old format), tag them immutable and anchor. Never delete.",
       "steps": [
         {
+          "call": "fileverse.list",
+          "map": {
+            "pattern": "**/*.json"
+          }
+        },
+        {
+          "call": "aci-legacy.detect",
+          "map": {
+            "files": "$steps.0",
+            "rules": {
+              "hivemind_root": "filename == 'hivemind.json'",
+              "total_recall": "filename startswith 'total_recall' && !has(parent)",
+              "presence_missing": "path startswith 'presence/' && !has(signature)"
+            }
+          }
+        },
+        {
           "call": "aci-checksum.batch",
           "map": {
             "files": "$steps.1.legacy_files"


### PR DESCRIPTION
## Summary
- add fileverse.list and aci-legacy.detect steps so the legacy adoption pipeline discovers eligible files
- keep checksum and timestamp inference steps aligned with the new discovery outputs to avoid undefined references

## Testing
- python - <<'PY'
import json
import re
from pathlib import Path

data = json.loads(Path('functions.json').read_text())
pipeline = data['pipelines']['aci.legacy.adopt']['steps']
pattern = re.compile(r"\\$steps\\.(\\d+)")
state = {"valid": True}

def check(value, current_step):
    if isinstance(value, str):
        for match in pattern.findall(value):
            idx = int(match)
            if idx >= current_step:
                print(f"Invalid reference: step {current_step} references future step {idx}")
                state["valid"] = False
    elif isinstance(value, dict):
        for v in value.values():
            check(v, current_step)
    elif isinstance(value, list):
        for v in value:
            check(v, current_step)

for i, step in enumerate(pipeline):
    check(step, i)

print("aci.legacy.adopt references are valid" if state["valid"] else "aci.legacy.adopt has invalid references")
PY

------
https://chatgpt.com/codex/tasks/task_e_68d02183dd588320815e16adbe245355