### PR TITLE
Remove stray code fence from nexus core JSON

### DIFF
--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -201,4 +201,3 @@
     "checksum_note": "Nexus Core is the canonical runtime spine. Resolvers are modular plugins, never baked into Core."
   }
 }
-```0


### PR DESCRIPTION
## Summary
- remove the stray Markdown code fence suffix from `entities/nexus_core/nexus_core.json`
- ensure the configuration terminates cleanly at the closing brace

## Testing
- python -m json.tool entities/nexus_core/nexus_core.json

------
https://chatgpt.com/codex/tasks/task_e_68d02174628c832093d7d82e5368a3ff