### PR TITLE
Fix binder JSON structure

### DIFF
--- a/entities/oracle/binder.json
+++ b/entities/oracle/binder.json
@@ -2,14 +2,12 @@
   "version": "1.0",
   "binder": {
     "description": "Binder for Oracle module — links runtime with library assets.",
-     } 
-      "library": {
-        "sefirot": "sefiton.json",
-        "tarot_rws": "tarot_rws.json",
-        "tarot_expansions": "tarot_expansions.json",
-        "runes_futhark": "runes_futhark.json",
-        "astro_tables": "astro_tables.json"
-      }
+    "library": {
+      "sefirot": "sefiton.json",
+      "tarot_rws": "tarot_rws.json",
+      "tarot_expansions": "tarot_expansions.json",
+      "runes_futhark": "runes_futhark.json",
+      "astro_tables": "astro_tables.json"
     },
     "rules": {
       "library_files_are_static": true,


### PR DESCRIPTION
## Summary
- fix the binder definition so that the library, rules, and runtime sections stay nested inside the binder object
- ensure the JSON is well formatted for the Oracle binder configuration

## Testing
- jq . entities/oracle/binder.json

------
https://chatgpt.com/codex/tasks/task_e_68d00ebb92d8832097c17e3da4e2f59e