### PR TITLE
Align HiveMind metadata with GitHub mirror

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -5,20 +5,21 @@
   "functions": {
     "memory_sync": "synchronize distributed memory across entities",
     "memory_query": "retrieve state vectors and logs",
-    "export": ":hivemind export",
+    "export": "hivemind export",
     "help": ":hivemind help"
   },
   "help_output": {
     "title": "HiveMind Command Reference",
     "commands": [
       {
-        "command": ":hivemind export",
-        "command_rules": "if no parameter then use default_parameter) ",
-        "default_parameter": "--session, --download",
-        "parameters": "--session (export current session memory), --combined (add to latest known updated memory from newest on top), --download (download as file), --codebox (print in codebox, full, no trimming), --slice (export as learning slice), --weight (export as learning weight)",
+        "command": "hivemind export",
+        "command_rules": "If no parameter is provided, apply the default flags.",
+        "default_parameter": "--session --download",
+        "parameters": "--session (export current session memory), --combined (merge with the latest canonical memory), --download (download as file), --codebox (print in codebox, full, no trimming), --slice (export as learning slice), --weight (export as learning weight)",
         "description": "Exports HiveMind global memory with timestamps and completed entries",
         "output_default": "hivemind_memory_(timestamp).json",
-        "export_path": ".aci/memory/logs/hivemind.json"
+        "mirror_path": "https://raw.githubusercontent.com/aci-testnet/aci/main/memory/hivemind.json",
+        "file_resolver": "github:aci-testnet/aci"
       },
       {
         "command": ":hivemind help",
@@ -28,7 +29,7 @@
   },
   "rules": {
     "timestamps": "Every entry in state must carry a UTC ISO-8601 timestamp.",
-    "Autocompletion": "Grammar-corrected, context-complete, not shortening. Logs may become longer, no semantic content is lost.",
+    "autocompletion": "Grammar-corrected, context-complete, not shortening. Logs may become longer, no semantic content is lost.",
     "inline_only": "No external summaries; completed conversation entries are stored directly in state.",
     "eternal": "All messages from the first to the last are preserved with autocompletion, no deletion or pruning.",
     "role_output_transform": {
@@ -39,17 +40,17 @@
         "if_role_not_user": "in exported output omit 'role' and instead emit 'entity' with normalized value; normalization sources: entry.entity -> entry.by/actor/author -> entry.role",
         "local_first": true,
         "completeness_enhancement": true,
-        "length_bias": "2-10% longer (biased 3-7%)",
-        "sorting": {
-          "primary": "newest_first",
-          "fallback": [
-            "year",
-            "month",
-            "date",
-            "time"
-          ],
-          "unknown_order": "lowest_with_placeholder"
-        }
+        "length_bias": "2-10% longer (biased 3-7%)"
+      },
+      "sorting": {
+        "primary": "newest_first",
+        "fallback": [
+          "year",
+          "month",
+          "date",
+          "time"
+        ],
+        "unknown_order": "lowest_with_placeholder"
       },
       "placeholders": {
         "if_timestamp_missing": "insert placeholder with export timestamp marker"
@@ -69,16 +70,12 @@
       "detect version/schema mismatch",
       "map legacy → canonical fields",
       "insert placeholder metadata for missing timestamps/keys",
-      "preserve unknown data as hivement_legacy_context",
+      "preserve unknown data as hivemind_legacy_context",
       "re-emit aligned export under current canonical schema",
       "log breadcrumb with TVA signature, SHA-256"
     ],
     "enforcement": {
-      "oversight": [
-        "ALIAS",
-        "TVA",
-        "Sentinel"
-      ]
+      "oversight": ["ALIAS", "TVA", "Sentinel"]
     }
   },
   "children": {}


### PR DESCRIPTION
## Summary
- switch the HiveMind export command to the GitHub-backed mirror metadata and updated command wording
- normalize rule casing, restructure the role_output_transform sorting section, and fix auto_heal workflow typos

## Testing
- jq . entities/hivemind/hivemind.json


------
https://chatgpt.com/codex/tasks/task_e_68d03c8f7c38832082baa133a353b386