### PR TITLE
Add sandbox configuration and default interface bootstrap

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -26,6 +26,37 @@
         "path": "entities/nexus_core/nexus_core.json",
         "ref": "main"
       }
+    },
+    "sandbox_mode": {
+      "enabled": true,
+      "core_files": [
+        "aci_runtime.json",
+        "prime_directive.txt"
+      ],
+      "initialization_sequence": [
+        {
+          "step": "verify_core_files",
+          "action": "confirm_required_files_present"
+        },
+        {
+          "step": "bootstrap_runtime",
+          "action": "initialize_core_systems"
+        },
+        {
+          "step": "launch_default_interface",
+          "action": "render_mother_interface"
+        }
+      ]
+    },
+    "default_interface": {
+      "path": "entities/mother/mother.json",
+      "resolver": {
+        "type": "github",
+        "repo": "aci-testnet/aci",
+        "path": "entities/mother/mother.json",
+        "ref": "main"
+      },
+      "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
     }
   }
 }


### PR DESCRIPTION
## Summary
- introduce a sandbox_mode configuration that enforces required core files and boot sequencing
- configure the default interface to launch the MU/TH/UR governance manifest with an initialization prompt

## Testing
- jq . aci_runtime.json

------
https://chatgpt.com/codex/tasks/task_e_68d27e5b54448320a00fa22f74a4f3a4