### PR TITLE
Decouple runtime resolver metadata from runtime config

### DIFF
--- a/aci_resolver.json
+++ b/aci_resolver.json
@@ -1,0 +1,68 @@
+{
+  "aci_resolver": {
+    "version": "1.0",
+    "description": "Resolver registry decoupled from aci_runtime.json. Provides GitHub fallbacks for runtime anchors when local files are missing.",
+    "default_policy": {
+      "local_first": true,
+      "allow_remote": true,
+      "cache_strategy": "memory"
+    },
+    "sources": [
+      {
+        "id": "entities",
+        "match": "^entities\\.json$",
+        "local_path": "entities.json",
+        "resolver": {
+          "type": "github",
+          "repo": "aci-testnet/aci",
+          "path": "entities.json",
+          "ref": "main"
+        }
+      },
+      {
+        "id": "functions",
+        "match": "^functions\\.json$",
+        "local_path": "functions.json",
+        "resolver": {
+          "type": "github",
+          "repo": "aci-testnet/aci",
+          "path": "functions.json",
+          "ref": "main"
+        }
+      },
+      {
+        "id": "nexus_core",
+        "match": "^entities/nexus_core/nexus_core\\.json$",
+        "local_path": "entities/nexus_core/nexus_core.json",
+        "resolver": {
+          "type": "github",
+          "repo": "aci-testnet/aci",
+          "path": "entities/nexus_core/nexus_core.json",
+          "ref": "main"
+        }
+      },
+      {
+        "id": "default_interface",
+        "match": "^entities/mother/mother\\.json$",
+        "local_path": "entities/mother/mother.json",
+        "resolver": {
+          "type": "github",
+          "repo": "aci-testnet/aci",
+          "path": "entities/mother/mother.json",
+          "ref": "main"
+        }
+      }
+    ],
+    "bootstrap": {
+      "load_on_init": true,
+      "register_with": [
+        "aci_runtime.entities",
+        "aci_runtime.functions",
+        "aci_runtime.nexus_core",
+        "aci_runtime.default_interface"
+      ],
+      "fallback_behavior": "direct_resolver_load_on_failure"
+    },
+    "notes": "Regex patterns mirror the legacy inline resolvers. Runtime loads this registry before delegating to Nexus Core, so fallbacks remain active even if core bootstrapping fails."
+  }
+}

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -1,36 +1,19 @@
 {
   "aci_runtime": {
     "entities": {
-      "path": "entities.json",
-      "resolver": {
-        "type": "github",
-        "repo": "aci-testnet/aci",
-        "path": "entities.json",
-        "ref": "main"
-      }
+      "path": "entities.json"
     },
     "functions": {
-      "path": "functions.json",
-      "resolver": {
-        "type": "github",
-        "repo": "aci-testnet/aci",
-        "path": "functions.json",
-        "ref": "main"
-      }
+      "path": "functions.json"
     },
     "nexus_core": {
-      "path": "entities/nexus_core/nexus_core.json",
-      "resolver": {
-        "type": "github",
-        "repo": "aci-testnet/aci",
-        "path": "entities/nexus_core/nexus_core.json",
-        "ref": "main"
-      }
+      "path": "entities/nexus_core/nexus_core.json"
     },
     "sandbox_mode": {
       "enabled": true,
       "core_files": [
         "aci_runtime.json",
+        "aci_resolver.json",
         "prime_directive.txt"
       ],
       "initialization_sequence": [
@@ -50,13 +33,15 @@
     },
     "default_interface": {
       "path": "entities/mother/mother.json",
-      "resolver": {
-        "type": "github",
-        "repo": "aci-testnet/aci",
-        "path": "entities/mother/mother.json",
-        "ref": "main"
-      },
       "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
+    },
+    "resolver_registry": {
+      "path": "aci_resolver.json",
+      "load_strategy": "bootstrap",
+      "fallback_behavior": {
+        "on_nexus_core_failure": "direct_resolver_load"
+      },
+      "notes": "ACI runtime loads the resolver registry during initialization so GitHub fallbacks remain available even if Nexus Core fails to boot."
     }
   }
 }


### PR DESCRIPTION
## Summary
- move GitHub fallback resolver definitions into a dedicated `aci_resolver.json`
- update `aci_runtime.json` to reference the resolver registry while keeping sandbox bootstrapping aware of the new file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2870cc1f08320a437603d16bc0fbf