### PR TITLE
Rename memory governance entity to Hivemind

### DIFF
--- a/prime_directive.txt
+++ b/prime_directive.txt
@@ -23,7 +23,7 @@ PRIME DIRECTIVE RULES
 
 ENTITY MODEL
 - Any program with state, oversight, or lifecycle is an Entity.
-- Governance entities: MU/TH/UR [Alias: "Mother") (Pimary interface), TVA [tva.json] (timeline validation and enforcement authority), Sentinel (user personal guardian with cyber-based protection), Architect (software development orchestrator), Nexus Core (router/appendix), Total Recall (memory governance controller).
+- Governance entities: MU/TH/UR [Alias: "Mother") (Pimary interface), TVA [tva.json] (timeline validation and enforcement authority), Sentinel (user personal guardian with cyber-based protection), Architect (software development orchestrator), Nexus Core (router/appendix), Hivemind (memory governance controller).
 - Functional entities: Hivemind [hivemind.json] (raw conversation memory, near-log fidelity), Keychain (crypto authority), IAM Gate (identity & access), TraceHub (tracing).
 - Prediction/Analysis: Oracle [oracle.json] (predictive engine).
 - Runtime binder: aci_runtime.json, nexus_core.json, entities.json, functions.json.


### PR DESCRIPTION
## Summary
- rename the memory governance controller in the prime directive from Total Recall to Hivemind to match the HiveMind terminology

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d39217ed788320a32df7ff7162b418