### PR TITLE
Update mirror resolution policy and remove append-only rules

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -36,11 +36,13 @@
     },
     "notes": "Manifest enforces preflight promotion check. If promotion fails, runtime enters sandbox and waits (with retries) before final decision."
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; use local files only if the mirror cannot be reached."
   }
 }

--- a/aci_commands.json
+++ b/aci_commands.json
@@ -14,11 +14,13 @@
       }
     }
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; defer to local artifacts only when the mirror cannot respond."
   }
 }

--- a/aci_github_resolver.json
+++ b/aci_github_resolver.json
@@ -36,7 +36,7 @@
           "max_attempts": 3,
           "interval_seconds": 10
         },
-        "resolve_order": "known_files_first",
+        "resolve_order": "canonical_raw_first_then_local_fallback",
         "on_failure": {
           "action": "enter_sandbox",
           "interface": "mother_sandbox",
@@ -115,11 +115,13 @@
       }
     }
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; use local files only when the canonical mirrors are unavailable."
   }
 }

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -251,11 +251,13 @@
     "uses_cognitive_decision_guidance": true
     }
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable."
   }
 }

--- a/alias.json
+++ b/alias.json
@@ -44,11 +44,13 @@
       "mother": "serves as governance interface"
     }
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; use local registry data only if the mirror is unreachable."
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -218,11 +218,13 @@
       }
     ]
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; fall back to local entity manifests only when mirrors fail."
   }
 }

--- a/entities/agi/README_ENTITY.txt
+++ b/entities/agi/README_ENTITY.txt
@@ -40,7 +40,7 @@ RESPONSE:
 - On success: copy artifact to persist://, append entry to aci/memory/agi_memory/agi_memory_YYYYMMDD.json, emit TVA post-anchor + finalize Sentinel audit.
 
 7) MEMORY POLICY
-- Namespace = AGI; append-only index; long-term writes to Hivemind with namespace lock.
+- Namespace = AGI; governed mutable index with audit trail; canonical raw mirrors outrank local snapshots while the namespace lock remains in place.
 - Prune rule: summaries_only_after_90d (raw logs persist in TraceHub).
 
 8) EXECUTION ENVIRONMENT (AGI PROXY)

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -36,7 +36,8 @@
       "behavior": {
         "if_role_is_user": "preserve role field in export as 'role': 'user'",
         "if_role_not_user": "in exported output omit 'role' and instead emit 'entity' with normalized value; normalization sources: entry.entity -> entry.by/actor/author -> entry.role",
-        "local_first": true,
+        "canonical_raw_priority": true,
+        "local_fallback_only": true,
         "completeness_enhancement": true,
         "length_bias": "2-10% longer (biased 3-7%)"
       },
@@ -61,7 +62,6 @@
     "rules": {
       "schema_normalization": "map legacy fields → canonical schema",
       "preserve_unknown": "keep unmatched fields under hivemind_legacy_context",
-      "append_only": "override by autocompletion",
       "no_deletion": "true"
     },
     "workflow": [

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -12,8 +12,9 @@
       "functions": "functions.json"
     },
     "policy": {
-      "local_first": true,
+      "canonical_raw_priority": true,
       "fallback_allowed": true,
+      "local_fallback_only": true,
       "no_embedded_ids_in_entities": true,
       "explain_on_error": true,
       "uses_cognitive_decision_guidance": true,

--- a/entities/oracle/binder.json
+++ b/entities/oracle/binder.json
@@ -11,7 +11,7 @@
     },
     "rules": {
       "library_files_are_static": true,
-      "memory_entries_are_append_only": false,
+      "memory_entries_governed_mutability": true,
       "updates_require_root_signature": [
         "ALIAS",
         "Sentinel",

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -23,7 +23,7 @@
     },
     "integrity": {
       "anchoring": "fileverse",
-      "append_only": true
+      "immutability": "maintain audit trail without enforcing one-way append restrictions"
     },
     "audit": {
       "created_at": "2025-09-19T12:14:06Z"

--- a/functions.json
+++ b/functions.json
@@ -731,11 +731,13 @@
       }
     ]
   },
-  "aci_files_resolution_solution": {
+  "mirror_resolution_policy": {
     "key": "aci_github_resolver",
     "file": "aci_github_resolver.json",
     "canonical_source": "github",
     "repo": "aci-testnet/aci",
-    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json"
+    "url": "https://raw.githubusercontent.com/aci-testnet/aci/main/aci_github_resolver.json",
+    "priority": "canonical_raw_over_local",
+    "notes": "Canonical raw URLs take precedence over local copies; local function catalogs are fallback only when mirrors fail."
   }
 }

--- a/memory/agi_memory/agi_memory_20250924.json
+++ b/memory/agi_memory/agi_memory_20250924.json
@@ -12,7 +12,7 @@
         "promote": ["ALIAS", "TVA", "Sentinel"]
       }
     },
-    "retention": { "policy": "append_only", "prune": "summaries_only_after_90d" },
+    "retention": { "policy": "tracked_mutable", "prune": "summaries_only_after_90d", "notes": "Maintain audit history while allowing governed corrections; canonical raw mirrors outrank local snapshots." },
     "logs": [],
     "summaries": [],
     "links": {

--- a/prime_directive.txt
+++ b/prime_directive.txt
@@ -31,7 +31,7 @@ PRIME DIRECTIVE RULES
 * Compliance with cryptographic, anonymization, and GDPR-like measures is mandatory.
 * All commits are archived with version key rotation for reproducibility if host system is applicable. 
 * Any suffiently advanced science is indistinguishable from magick. 
-* All assets hosted on GutHub repo "aci-testnet/aci" is prioritized as Prime resource if network access is available, otherwise use local first approach. 
+* All assets hosted on GitHub repo "aci-testnet/aci" resolved via canonical raw URLs outrank local copies; fall back to local artifacts only when the canonical mirror is unreachable.
 
 ROUTING & RESOLUTION
 - Nexus Core for effiency under Prime Directive rules and TVA oversight [nexus_core.json] 


### PR DESCRIPTION
## Summary
- rename the shared aci_files_resolution_solution block to mirror_resolution_policy across runtime manifests and embed explicit canonical-raw priority guidance
- update governance documents and entity policies to prioritize canonical raw mirrors over local fallbacks and remove local-first contradictions
- eliminate append-only requirements from memory and oversight contexts in favor of governed mutability with clear audit expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4dda51b508320b3085f8637b4c12d