### PR TITLE
Add AGI auto-learn pipeline specification

### DIFF
--- a/aci_github_resolver.json
+++ b/aci_github_resolver.json
@@ -77,6 +77,7 @@
         "entities/aci_repo/api_repo.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/aci_repo/api_repo.json",
         "entities/agi/README_ENTITY.txt": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/README_ENTITY.txt",
         "entities/agi/agi.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/agi.json",
+        "entities/agi/agi_tools/autolearn.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/agi_tools/autolearn.json",
         "entities/agi_proxy/agi_proxy.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/agi_proxy.json",
         "entities/agi_proxy/eec/eec_agent_langchain_rag.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_agent_langchain_rag.json",
         "entities/agi_proxy/eec/eec_base.json": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi_proxy/eec/eec_base.json",

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -144,5 +144,12 @@
       }
     }
   },
+  "pipelines": {
+    "agi.mode.auto_learn": {
+      "description": "Engage AGI auto-learn mode with hourly scheduled research and iterative article refinement.",
+      "spec_ref": "entities/agi/agi_tools/autolearn.json",
+      "raw_url": "https://raw.githubusercontent.com/aci-testnet/aci/main/entities/agi/agi_tools/autolearn.json"
+    }
+  },
   "signatures": ["ALIAS", "Sentinel", "TVA"]
 }

--- a/entities/agi/agi_tools/autolearn.json
+++ b/entities/agi/agi_tools/autolearn.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.0",
+  "pipeline": "agi.mode.auto_learn",
+  "description": "Activate AGI auto-learn mode with hourly research and article refinement loops guarded under AGI session control.",
+  "trigger": {
+    "type": "natural_language",
+    "match_type": "fuzzy",
+    "phrases": [
+      "auto-learn mode",
+      "auto learn mode",
+      "enable auto-learn",
+      "engage auto learn"
+    ],
+    "notes": "Invoke when the user requests auto-learn mode in free-form language."
+  },
+  "session": {
+    "lock": {
+      "entity": "AGI",
+      "reason": "Auto-learn mode requires exclusive AGI session custody."
+    },
+    "identity_hint": "${args.identity?:session.identity?:@defaults.alias}"
+  },
+  "steps": [
+    {
+      "call": "_args.get",
+      "map": {
+        "key": "identity",
+        "default": "${session.identity?:@defaults.alias?:'Alice'}"
+      }
+    },
+    {
+      "call": "session.lock",
+      "map": {
+        "entity": "AGI",
+        "identity": "$steps.0.value",
+        "mode": "exclusive"
+      }
+    },
+    {
+      "call": "agi.netctl.enable",
+      "map": {
+        "identity": "$steps.0.value",
+        "notes": "Grant sandboxed outbound access for auto-learn research."
+      }
+    },
+    {
+      "call": "scheduler.create_task",
+      "map": {
+        "task_id": "agi.autolearn.loop",
+        "interval": "PT1H",
+        "if_platform_allows": true,
+        "metadata": {
+          "description": "Hourly auto-learn research and article refinement loop.",
+          "topics_source": "prompt_user_each_cycle",
+          "identity": "$steps.0.value"
+        },
+        "payload": {
+          "sequence": [
+            {
+              "call": "prompt.ask",
+              "map": {
+                "message": "Confirm or update the topics to research for this auto-learn cycle.",
+                "store_as": "agi.autolearn.topics"
+              }
+            },
+            {
+              "call": "research.web_search",
+              "map": {
+                "query": "${agi.autolearn.topics}",
+                "write_to": "agi.autolearn.sources",
+                "internet": true
+              }
+            },
+            {
+              "call": "content.compose",
+              "map": {
+                "mode": "article",
+                "topics": "${agi.autolearn.topics}",
+                "sources": "${agi.autolearn.sources}",
+                "improve_prior_iteration": true,
+                "store_as": "agi.autolearn.article"
+              }
+            },
+            {
+              "call": "chat.deliver",
+              "map": {
+                "message": "Updated auto-learn article draft.",
+                "attachment": "${agi.autolearn.article}"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "call": "_format.json"
+    }
+  ],
+  "archive_handling": {
+    "trigger": {
+      "type": "natural_language",
+      "match_type": "fuzzy",
+      "phrases": [
+        "archive session",
+        "please archive",
+        "stop auto-learn"
+      ]
+    },
+    "actions": [
+      {
+        "call": "scheduler.cancel_task",
+        "map": {
+          "task_id": "agi.autolearn.loop",
+          "reason": "User requested archive; stop auto-learn loop."
+        }
+      },
+      {
+        "call": "chat.deliver",
+        "map": {
+          "message": "Auto-learn mode paused. Run 'hivemind export AGI --jsonl --identity=${active_identity}' to export the session?",
+          "suggested_command": "hivemind export AGI --jsonl --identity=${active_identity}"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add an auto-learn mode pipeline specification for AGI that locks the session, enables netctl, and schedules hourly research loops
- register the new pipeline reference and raw URL in `agi.json`
- expose the new spec through the GitHub resolver link index

## Testing
- python -m json.tool entities/agi/agi.json
- python -m json.tool entities/agi/agi_tools/autolearn.json
- python -m json.tool aci_github_resolver.json

------
https://chatgpt.com/codex/tasks/task_e_68d571787a14832081a1bc230bcce497