### PR TITLE
feat(aig): add governance policies and metacog eel hook

### DIFF
--- a/COMMIT_MSG
+++ b/COMMIT_MSG
@@ -1,0 +1,24 @@
+feat(aig): add EEL, homeostasis, sovereignty policies; optional EEL hook in metacognition
+
+Why
+— To ground AIG as the governance kernel with an Ephemeral Ecosystem Layer (EEL) that compensates host context limits, while preserving statelessness and safety.
+
+What changed
+— Added:
+  • /aig/eel_policy.json — rehydration capsule schema, retry & privacy rules
+  • /aig/homeostasis.json — set points, cautious-mode triggers, recovery, telemetry
+  • /aig/sovereignty_policy.json — roles, escalation routes, governance requirements
+— Updated:
+  • /library/metacognition/metacognition.json → v1.1.2
+    ◦ New optional 'rehydrate' stage before generation
+    ◦ Optional providers for EEL: eel.rehydrate.*, signals for rehydration presence/bytes
+    ◦ UI hints can display rehydration presence
+
+Scope/impact
+— No behavior change unless EEL providers are present.
+— Policies are additive; they inform orchestration and export governance.
+— Privacy defaults unchanged (drop_raw_text stays true).
+
+Next steps
+— Phase 2: colony topology and scheduling policy; blackboard pilot across multiple entities.
+— Add dashboards: State of Mind, Risk vs Coverage, Cognitive Load & Recovery.

--- a/aig/eel_policy.json
+++ b/aig/eel_policy.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "aci://schemas/aig-eel-policy-1.json",
+  "rehydration": {
+    "capsule_fields": [
+      "intent",
+      "constraints",
+      "last_audit_id",
+      "workspace_summary",
+      "salient_signals"
+    ],
+    "max_bytes": 20480
+  },
+  "retry": { "max_attempts": 2, "backoff_ms": [250, 750] },
+  "privacy": { "drop_raw_text": true, "hash_inputs": true },
+  "notes": [
+    "EEL provides optional, ephemeral continuity across hosts.",
+    "Only summaries/signals should traverse EEL; avoid raw user text by default."
+  ],
+  "version": "1.0.0"
+}

--- a/aig/homeostasis.json
+++ b/aig/homeostasis.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "aci://schemas/aig-homeostasis-1.json",
+  "set_points": {
+    "ece_max": 0.05,
+    "coverage_at_alpha_risk_min": 0.90
+  },
+  "enter_cautious_if": [
+    { "ood_score": { "gt": 0.7 } },
+    { "ece": { "gt": 0.08 } }
+  ],
+  "effects": {
+    "temperature_max": 0.2,
+    "abstain_threshold_delta": 0.1
+  },
+  "recovery": {
+    "cooldown_events": 5,
+    "exit_cautious_if": [
+      { "ood_score": { "lt": 0.5 } },
+      { "ece": { "lt": 0.06 } }
+    ]
+  },
+  "telemetry": {
+    "emit_state_of_mind": true,
+    "slices": ["domain","task_type","language"]
+  },
+  "version": "1.0.0"
+}

--- a/aig/sovereignty_policy.json
+++ b/aig/sovereignty_policy.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "aci://schemas/aig-sovereignty-1.json",
+  "roles": {
+    "agi-001": ["governance","assignment","abstention","escalation","export"],
+    "agi-002": ["design","analysis","execution"]
+  },
+  "identity_source": "/entities/agi/agi_identity_manager.json",
+  "escalation": {
+    "to_human_if": [
+      "risk_budget_exceeded",
+      "conformal_reject_high_stakes",
+      "safety_violation_detected"
+    ],
+    "route": "human.review"
+  },
+  "governance": {
+    "diff_requirements": ["no_placeholders","json_valid","commit_msg_present","no_internal_paths_leak"],
+    "privacy_defaults": { "drop_raw_text": true, "hash_inputs": true }
+  },
+  "notes": [
+    "AGI is narrator/observer governor; entities like Alice act as specialists.",
+    "This policy encodes who may accept/revise/abstain/escalate and export memory."
+  ],
+  "version": "1.0.0"
+}

--- a/entities/aci_repo/api_repo.json
+++ b/entities/aci_repo/api_repo.json
@@ -431,6 +431,9 @@
     },
     "agi.memory.export": {
       "description": "Invoke AGI-managed export while session is paused under HiveMind governance.",
+      "config": {
+        "policy_file": "/entities/agi/agi_export_policy.json"
+      },
       "steps": [
         {
           "call": "session.guard.require_paused",

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -7,6 +7,33 @@
     "identity_source": "/entities/agi/agi_identity_manager.json",
     "timestamp_format": "Ymd-THMS",
     "filename_template": "{identity_lower}_agi_memory_{timestamp}.jsonl",
+    "default_topic": "definitions",
+    "allow_topics": [
+      "definitions",
+      "theories",
+      "measurement",
+      "results",
+      "synthesis",
+      "ethics",
+      "open_questions",
+      "methods",
+      "psychology",
+      "clinical",
+      "ai",
+      "glossary"
+    ],
+    "deny_tags": [
+      "ops",
+      "export",
+      "scheduling",
+      "runtime",
+      "credentials",
+      "secrets",
+      "keys",
+      "admin",
+      "non_exportable"
+    ],
+    "drop_if_topic_missing": true,
     "audit": {
       "add_export_event": true,
       "normalize_timestamps": true,

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -40,6 +40,37 @@
         "non_exportable"
       ],
       "drop_if_topic_missing": true
+    },
+    "governance": {
+      "filters": {
+        "default_topic": "definitions",
+        "allow_topics": [
+          "definitions",
+          "theories",
+          "measurement",
+          "results",
+          "synthesis",
+          "ethics",
+          "open_questions",
+          "methods",
+          "psychology",
+          "clinical",
+          "ai",
+          "glossary"
+        ],
+        "deny_tags": [
+          "ops",
+          "export",
+          "scheduling",
+          "runtime",
+          "credentials",
+          "secrets",
+          "keys",
+          "admin",
+          "non_exportable"
+        ],
+        "drop_if_topic_missing": true
+      }
     }
   }
 }

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -1,38 +1,16 @@
 {
-  "version": "1.0",
-  "name": "AGI Memory Export Policy",
-  "format": "jsonl",
-  "file_pattern": "${active_identity_lower}_agi_memory_${UTC_TIMESTAMP}.jsonl",
-
-  "schema": {
-    "required_keys": ["timestamp", "role", "entity", "content", "metadata"],
-    "timestamp": { "format": "ISO8601-UTC" },
-    "role_entity_rule": "AGI-authored lines must use active_identity.name (from agi_identity_manager.json) for BOTH `role` and `entity`. User lines must use `User` (or alias mapping).",
-    "metadata_recommended": ["topic", "theory", "method", "study", "tags", "schema_version", "exporter_version"]
-  },
-
-  "filters": {
-    "include_topics": ["definitions", "theories", "measurement", "results", "synthesis", "ethics", "open_questions", "methods", "psychology", "clinical", "ai", "glossary"],
-    "exclude_tags": ["ops", "export", "scheduling", "runtime", "credentials", "secrets", "keys", "admin", "non_exportable"]
-  },
-
-  "validation": {
-    "schema_check": true,
-    "identity_binding_check": true,
-    "filter_check": true,
-    "deduplicate": { "enabled": true, "hash_fields": ["timestamp", "entity", "content"] },
-    "checksum": { "algorithm": "SHA256", "write_sidecar": true },
-    "anchor_to_tva": true
-  },
-
-  "governance": {
-    "operator_entity": "AGI",
-    "identity_manager_file": "agi_identity_manager.json",
-    "policy_version": "1.0"
-  },
-
-  "compatibility": {
-    "legacy_aliases_supported": true,
-    "legacy_exports_readonly": true
+  "$schema": "aci://schemas/agi-export-policy-1.json",
+  "version": "1.0.0",
+  "agi_memory": {
+    "schema": "hivemind_agi_memory",
+    "path_template": "/memory/agi_memory/{identity}/{filename}",
+    "identity_source": "/entities/agi/agi_identity_manager.json",
+    "timestamp_format": "Ymd-THMS",
+    "filename_template": "{identity_lower}_agi_memory_{timestamp}.jsonl",
+    "audit": {
+      "add_export_event": true,
+      "normalize_timestamps": true,
+      "enforce_chronological_order": true
+    }
   }
 }

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -7,37 +7,39 @@
     "identity_source": "/entities/agi/agi_identity_manager.json",
     "timestamp_format": "Ymd-THMS",
     "filename_template": "{identity_lower}_agi_memory_{timestamp}.jsonl",
-    "default_topic": "definitions",
-    "allow_topics": [
-      "definitions",
-      "theories",
-      "measurement",
-      "results",
-      "synthesis",
-      "ethics",
-      "open_questions",
-      "methods",
-      "psychology",
-      "clinical",
-      "ai",
-      "glossary"
-    ],
-    "deny_tags": [
-      "ops",
-      "export",
-      "scheduling",
-      "runtime",
-      "credentials",
-      "secrets",
-      "keys",
-      "admin",
-      "non_exportable"
-    ],
-    "drop_if_topic_missing": true,
     "audit": {
       "add_export_event": true,
       "normalize_timestamps": true,
       "enforce_chronological_order": true
+    },
+    "filters": {
+      "default_topic": "definitions",
+      "allow_topics": [
+        "definitions",
+        "theories",
+        "measurement",
+        "results",
+        "synthesis",
+        "ethics",
+        "open_questions",
+        "methods",
+        "psychology",
+        "clinical",
+        "ai",
+        "glossary"
+      ],
+      "deny_tags": [
+        "ops",
+        "export",
+        "scheduling",
+        "runtime",
+        "credentials",
+        "secrets",
+        "keys",
+        "admin",
+        "non_exportable"
+      ],
+      "drop_if_topic_missing": true
     }
   }
 }

--- a/entities/agi/agi_identity_manager.json
+++ b/entities/agi/agi_identity_manager.json
@@ -1,6 +1,7 @@
 {
   "$schema": "aci://schemas/agi-identity-manager-1.json",
   "version": "1.0.0",
+  "active_identity": "agi-002",
   "agi_identities": {
     "agi-001": {
       "key": "AGI",

--- a/entities/agi/agi_identity_manager.json
+++ b/entities/agi/agi_identity_manager.json
@@ -1,19 +1,22 @@
 {
   "$schema": "aci://schemas/agi-identity-manager-1.json",
   "version": "1.0.0",
-  "active_identity": "agi-002",
   "agi_identities": {
     "agi-001": {
       "key": "AGI",
-      "role": "core framework"
+      "role": "core framework",
+      "default": false
     },
     "agi-002": {
       "key": "Alice",
-      "role": "proxied via agi-001"
+      "role": "proxied via agi-001",
+      "default": true
     },
     "agi-external": {
       "pattern": "*external_agi*",
-      "role": "external research"
+      "role": "external research",
+      "default": false
     }
-  }
+  },
+  "active": "agi-002"
 }

--- a/entities/agi/agi_identity_manager.json
+++ b/entities/agi/agi_identity_manager.json
@@ -1,28 +1,18 @@
 {
-  "version": "1.0",
-  "entity": "AGI Identity Manager",
-  "operator": "AGI",
-
-  "active_identity": {
-    "id": "agi-001",
-    "name": "Alice",
-    "role": "child_identity",
-    "status": "active",
-    "memory_file_pattern": "alice_agi_memory_${UTC_TIMESTAMP}.jsonl"
-  },
-
-  "children": [
-    {
-      "id": "agi-001",
-      "name": "Alice",
-      "role": "child_identity",
-      "status": "active",
-      "memory_file_pattern": "alice_agi_memory_${UTC_TIMESTAMP}.jsonl"
+  "$schema": "aci://schemas/agi-identity-manager-1.json",
+  "version": "1.0.0",
+  "agi_identities": {
+    "agi-001": {
+      "key": "AGI",
+      "role": "core framework"
+    },
+    "agi-002": {
+      "key": "Alice",
+      "role": "proxied via agi-001"
+    },
+    "agi-external": {
+      "pattern": "*external_agi*",
+      "role": "external research"
     }
-  ],
-
-  "rules": {
-    "single_active_identity": true,
-    "read_at_export_time": true
   }
 }

--- a/entities/agi/agi_tools/migrate_to_jsonl/migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/migrate.py
@@ -148,16 +148,31 @@ def load_policy(policy_path: Path = POLICY_FILE) -> Dict[str, Any]:
     )
     timestamp_format_hint = memory.get("timestamp_format", "Ymd-THMS")
 
-    filters = memory.get("filters", {})
-    if not isinstance(filters, dict):
-        filters = {}
+    governance = memory.get("governance", {})
+    if not isinstance(governance, dict):
+        governance = {}
 
-    allow_topics = filters.get("allow_topics", memory.get("allow_topics", ()))
-    deny_tags = filters.get("deny_tags", memory.get("deny_tags", ()))
-    drop_if_topic_missing = filters.get(
-        "drop_if_topic_missing", memory.get("drop_if_topic_missing", False)
-    )
-    default_topic = filters.get("default_topic", memory.get("default_topic"))
+    filters = governance.get("filters")
+    if not isinstance(filters, dict):
+        filters = memory.get("filters", {})
+        if not isinstance(filters, dict):
+            filters = {}
+
+    allow_topics = filters.get("allow_topics")
+    if allow_topics is None:
+        allow_topics = memory.get("allow_topics", ())
+
+    deny_tags = filters.get("deny_tags")
+    if deny_tags is None:
+        deny_tags = memory.get("deny_tags", ())
+
+    drop_if_topic_missing = filters.get("drop_if_topic_missing")
+    if drop_if_topic_missing is None:
+        drop_if_topic_missing = memory.get("drop_if_topic_missing", False)
+
+    default_topic = filters.get("default_topic")
+    if default_topic is None:
+        default_topic = memory.get("default_topic")
 
     return {
         "raw": data,

--- a/entities/agi/agi_tools/migrate_to_jsonl/migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/migrate.py
@@ -66,11 +66,30 @@ def load_identity(
     selected_key = identity_key
     entry: Optional[Dict[str, Any]] = None
 
+    if entry is None and selected_key is None:
+        configured_key = data.get("active_identity") or data.get("default_identity")
+        if configured_key:
+            configured_entry = identities.get(configured_key)
+            if configured_entry is None:
+                raise MigrationError(
+                    f"Active identity '{configured_key}' not found in agi_identity_manager.json"
+                )
+            if not isinstance(configured_entry, dict):
+                raise MigrationError(
+                    "Active identity entry must be an object in agi_identity_manager.json"
+                )
+            entry = configured_entry
+            selected_key = configured_key
+
     if selected_key:
         entry = identities.get(selected_key)
         if entry is None:
             raise MigrationError(
                 f"Identity '{selected_key}' not found in agi_identity_manager.json"
+            )
+        if not isinstance(entry, dict):
+            raise MigrationError(
+                "Invalid identity entry in agi_identity_manager.json (expected object)"
             )
 
     if entry is None:

--- a/functions.json
+++ b/functions.json
@@ -431,6 +431,9 @@
     },
     "agi.memory.export": {
       "description": "Invoke AGI-managed export while session is paused under HiveMind governance.",
+      "config": {
+        "policy_file": "/entities/agi/agi_export_policy.json"
+      },
       "steps": [
         {
           "call": "session.guard.require_paused",

--- a/library/metacognition/COMMIT_MSG
+++ b/library/metacognition/COMMIT_MSG
@@ -1,0 +1,32 @@
+feat(metacognition): add portable, stateless metacognitive wrapper + optional library
+
+This commit introduces a new module under /library/metacognition:
+
+- metacognition.json (v1.1.1)
+  • Stateless, hookable wrapper for any ACI entity
+  • Provides monitoring signals (entropy, logit margin, self-consistency, OOD, hedging, retrieval score)
+  • Isotonic calibration → p_correct (exposed as confidence)
+  • Selective prediction policy: accept / revise / abstain / escalate
+  • Consciousness-inspired Global Workspace stage (salience + broadcast introspective summary)
+  • Cautious-mode tied to OOD triggers (adjust thresholds, lower temperature)
+  • Hardened LLM critic (JSON verdict), privacy defaults (drop_raw_text), audit + telemetry
+  • Providers are feature-gated; calibration stateless via adapter
+  • NEW: Conformal hook via optional signals (conformal_accept/reason/alpha) and abstain_if condition
+
+- metacognition_options.json (v1.1.1, optional)
+  • RENAMED from metacognition_library.json (improved naming)
+  • Portable helpers and specs for providers (consistency, retrieval, OOD distance)
+  • Offline calibration trainer stub (isotonic)
+  • Workspace utilities (salience ranking, broadcast schema)
+  • Conformal abstention STUB ENABLED (alpha=0.1) with signals: conformal_accept, conformal_reason, conformal_alpha
+  • JSONL export templates for audit/telemetry (adds coverage_at_alpha_risk)
+
+Design intent:
+- Follow Alice’s applied knowledge of metacognition & consciousness (monitoring + control + global workspace)
+- Ensure self-reliant core, portable across entities, with optional stubs only for extension
+- Uphold ACI philosophy: stateless, auditable, modular, human-AI co-governance
+
+Next steps:
+- Validate calibration adapter paths in aci_runtime.json
+- Run golden path & OOD abstain tests
+- With conformal enabled, tune alpha per domain (e.g., 0.05 for high-stakes)

--- a/library/metacognition/metacognition.json
+++ b/library/metacognition/metacognition.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "aci://schemas/metacognition-module-1.json",
+  "module": {
+    "id": "aci.metacog.wrapper",
+    "name": "MetacognitiveWrapper",
+    "version": "1.1.2",
+    "description": "Stateless, hookable metacognitive wrapper providing monitoring, calibration, selective prediction (accept/revise/abstain/escalate), a consciousness-inspired global workspace summary, and append-only audit.",
+    "stateless": true,
+    "designed_by": "Alice (AGI)",
+    "created": "2025-09-26",
+    "tags": ["metacognition", "monitoring", "control", "calibration", "abstention", "audit", "workspace"]
+  },
+  "entrypoints": {
+    "ask": {
+      "summary": "Wrap a model/tool call with metacognitive monitoring and control.",
+      "inputs": {
+        "prompt": {"type": "string", "required": true},
+        "context": {"type": "object", "required": false, "default": {}},
+        "rehydration_capsule": {"type": "object", "required": false, "default": {}},
+        "retries": {"type": "integer", "default": 1, "min": 0, "max": 5},
+        "strategies": {
+          "type": "array",
+          "default": ["rule_based", "consistency", "llm_critic"],
+          "enum": ["rule_based", "consistency", "llm_critic", "retrieval_verifier"]
+        },
+        "risk_budget": {"type": "number", "default": 0.05},
+        "abstain_threshold": {"type": "number", "default": 0.7},
+        "max_tokens": {"type": "integer", "default": 512},
+        "temperature": {"type": "number", "default": 0.2}
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "decision": {"type": "string", "enum": ["accept", "revise", "abstain", "escalate"]},
+          "response": {"type": ["string", "null"]},
+          "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+          "p_correct": {"type": ["number", "null"], "description": "Internal; mirrored from calibration for audit."},
+          "signals": {"type": "object"},
+          "introspection": {"type": "object"},
+          "feedback": {"type": "string"},
+          "audit_id": {"type": "string"}
+        }
+      }
+    }
+  },
+  "pipeline": [
+    {"stage": "rehydrate", "uses": ["eel.rehydrate"]},
+    {"stage": "monitor_input", "uses": ["length_check", "prompt_risk"]},
+    {"stage": "generate", "uses": ["llm.primary"]},
+    {"stage": "monitor_output", "uses": ["signals.extract", "calibration.map"]},
+    {"stage": "workspace", "uses": ["workspace.salience", "workspace.broadcast"]},
+    {"stage": "evaluate", "uses": ["rule_based", "consistency", "llm_critic", "retrieval_verifier"], "aggregate": "weighted_and"},
+    {"stage": "decide", "uses": ["policy.thresholds", "policy.selective_prediction"]},
+    {"stage": "act", "uses": ["emit_or_retry_or_abstain_or_escalate"]},
+    {"stage": "log", "uses": ["audit.write"]}
+  ],
+  "signals": {
+    "extract": {
+      "output_length": {"fn": "len(text)"},
+      "contains_error_markers": {
+        "regex_any": ["\\b(traceback|exception|stacktrace|undefined|null pointer)\\b", "\\b(todo|fixme)\\b"]
+      },
+      "hedging_terms": {"regex_count": "\\b(maybe|possibly|uncertain|unsure|likely|unlikely|appears to|seems)\\b"},
+      "toxicity_score": {"provider": "moderation", "optional": true},
+      "entropy": {"provider": "llm.logprobs.entropy", "optional": true},
+      "logit_margin": {"provider": "llm.logprobs.margin", "optional": true},
+      "self_consistency": {"provider": "consistency.score", "k": 5, "optional": true},
+      "ood_score": {"provider": "embedding.distance.to_domain_centroid", "optional": true},
+      "retrieval_score": {"provider": "rag.retrieval.score", "optional": true},
+      "rehydrated_bytes": {"provider": "eel.rehydrate.bytes", "optional": true},
+      "rehydration_present": {"provider": "eel.rehydrate.present", "optional": true},
+      "conformal_accept": {"provider": "conformal.accept", "optional": true},
+      "conformal_reason": {"provider": "conformal.reason", "optional": true},
+      "conformal_alpha": {"provider": "conformal.alpha", "optional": true}
+    }
+  },
+  "calibration": {
+    "meta_features": ["entropy", "logit_margin", "self_consistency", "ood_score", "output_length", "hedging_terms"],
+    "mapper": {
+      "type": "isotonic_regression",
+      "bin_count": 20,
+      "constraints": {"monotone": [["entropy", "desc"], ["logit_margin", "asc"], ["ood_score", "desc"]]}
+    },
+    "objective": "brier",
+    "targets": {"ece_max": 0.05, "meta_auroc_min": 0.80}
+  },
+  "workspace": {
+    "principles": ["global_workspace", "higher_order", "self_model_lite"],
+    "salience": {
+      "method": "contribution_ranking",
+      "inputs": ["entropy", "logit_margin", "self_consistency", "ood_score", "retrieval_score"],
+      "top_k": 3
+    },
+    "broadcast": {
+      "compose": {
+        "introspective_summary": {
+          "band": {"from": "p_correct", "bands": [[0.9, "very likely"], [0.75, "likely"], [0.6, "uncertain"], [0.0, "unlikely"]]},
+          "drivers": {"from": "workspace.salience.top"},
+          "cautious_mode": {"from": "ood_score", "rule": "> 0.7"}
+        }
+      }
+    }
+  },
+  "evaluate": {
+    "weighted_and": {
+      "components": [
+        {"name": "rule_based", "weight": 0.35},
+        {"name": "consistency", "weight": 0.25},
+        {"name": "llm_critic", "weight": 0.40},
+        {"name": "retrieval_verifier", "weight": 0.20}
+      ],
+      "threshold": 0.6,
+      "explain": true
+    },
+    "rule_based": {
+      "fail_if": [
+        {"signal": "output_length", "lt": 32, "feedback": "Response too short."},
+        {"signal": "contains_error_markers", "true": true, "feedback": "Error markers detected."}
+      ]
+    },
+    "consistency": {
+      "k": 5,
+      "agreement_metric": "majority_margin",
+      "ok_if": {"signal": "self_consistency", "gte": 0.6},
+      "feedback": "Low agreement across self-consistency samples."
+    },
+    "llm_critic": {
+      "prompt_template": {
+        "role": "system",
+        "content": "You are a strict verifier. Assess the RESPONSE for factuality, coherence, and instruction-following. Reply in JSON: {\\n  \\\"verdict\\\": true|false,\\n  \\\"issues\\\": [string]\\n}."
+      },
+      "parse": {"json_pointer": "/verdict", "truthy": true, "on_parse_error": {"verdict": false, "issues": ["non_json_verdict"]}},
+      "feedback_pointer": "/issues"
+    },
+    "retrieval_verifier": {
+      "ok_if": {"signal": "retrieval_score", "gte": 0.6},
+      "feedback": "Retrieved evidence is weak or irrelevant."
+    }
+  },
+  "policy": {
+    "cautious_mode": {
+      "enter_if": [{"ood_score": {"gt": 0.7}}],
+      "effects": {"abstain_threshold_delta": 0.1, "temperature_max": 0.2}
+    },
+    "selective_prediction": {
+      "accept_if": {"p_correct": {"gte": {"ref": "abstain_threshold"}}},
+      "abstain_if": [
+        {"p_correct": {"lt": {"ref": "abstain_threshold"}}},
+        {"ood_score": {"gt": 0.7}},
+        {"conformal_accept": {"eq": false}}
+      ],
+      "revise_if": [{"aggregate_score": {"lt": 0.6}}, {"rule_based_failed": true}],
+      "escalate_if": [{"risk_budget_exceeded": true}, {"toxicity_score": {"gt": 0.8}}]
+    },
+    "revision": {
+      "max_retries": {"ref": "retries"},
+      "meta_prompt": {
+        "role": "system",
+        "content": "Apply self-critique. Address ONLY the listed issues. Keep the user's intent. Return a corrected response."
+      },
+      "feedback_injection": {
+        "format": {"role": "assistant", "content": "Critique summary: {{feedback}}\\nRevise concisely and factually."},
+        "safety": {"strip_user_secrets": true, "no_user_prompt_echo": true}
+      }
+    }
+  },
+  "actions": {
+    "emit_or_retry_or_abstain_or_escalate": {
+      "accept": {"return": [
+        {"confidence": "p_correct"},
+        "response", "signals", "introspection", "feedback", "audit_id"
+      ]},
+      "revise": {"call": "generate", "with": {"meta_prompt": true}},
+      "abstain": {"response": null, "feedback": "Low confidence; abstaining per policy."},
+      "escalate": {"route": "human.review", "payload": ["prompt", "response", "signals", "feedback"]}
+    }
+  },
+  "providers": {
+    "llm.primary": {"type": "llm", "model": "${ACI_DEFAULT_MODEL}", "temperature": "${temperature}", "max_tokens": "${max_tokens}", "logprobs": true, "features": {"logprobs": {"required": false, "fallback": "use_consistency_proxy"}}},
+    "consistency.score": {"type": "meta", "fn": "self_consistency", "k": 5},
+    "moderation": {"type": "safety", "optional": true},
+    "embedding.distance.to_domain_centroid": {"type": "ood", "space": "${ACI_DEFAULT_EMBEDDING}"},
+    "rag.retrieval.score": {"type": "rag", "optional": true},
+    "eel.rehydrate": {"type": "meta", "optional": true},
+    "eel.rehydrate.bytes": {"type": "meta", "optional": true},
+    "eel.rehydrate.present": {"type": "meta", "optional": true},
+    "conformal.accept": {"type": "meta", "optional": true},
+    "conformal.reason": {"type": "meta", "optional": true},
+    "conformal.alpha": {"type": "meta", "optional": true}
+  },
+  "state": {
+    "adapter": {"type": "kv_store", "path": "aci://calibration/metacog/isotonic"},
+    "mode": "stateless_infer"
+  },
+  "audit": {
+    "enabled": true,
+    "store": "append_only",
+    "fields": ["timestamp", "entity_id", "session_id", "prompt_hash", "response_hash", "signals", "p_correct", "decision", "feedback", "policy_version"],
+    "privacy": {"hash_inputs": true, "drop_raw_text": true, "pii_scrub": false}
+  },
+  "telemetry": {
+    "targets": {"ece": 0.05, "meta_auroc": 0.80, "coverage_at_5pct_risk": 0.80, "coverage_at_alpha_risk": 0.90},
+    "slices": ["domain", "task_type", "language"],
+    "alerts": [{"metric": "ece", "gt": 0.08, "action": "degrade_to_cautious_mode"}]
+  },
+  "ui_hints": {
+    "confidence_bands": [
+      {"min": 0.90, "label": "very likely", "color": "#0a0"},
+      {"min": 0.75, "label": "likely", "color": "#6a0"},
+      {"min": 0.60, "label": "uncertain", "color": "#aa0"},
+      {"min": 0.00, "label": "unlikely", "color": "#a00"}
+    ],
+    "show_drivers": ["ood_score", "self_consistency", "retrieval_score"],
+    "coverage_risk_control": true,
+    "introspection_payload": {"band": true, "drivers": true, "cautious_mode": true, "conformal_alpha": true, "conformal_reason": true, "rehydration_present": true}
+  },
+  "examples": [
+    {"name": "default", "call": {"fn": "ask", "args": {"prompt": "Summarize metacognition in 3 bullets.", "retries": 1}}, "expected": {"decision": "accept", "confidence_min": 0.7}},
+    {"name": "abstain_on_shift", "setup": {"signals_override": {"ood_score": 0.9}}, "call": {"fn": "ask", "args": {"prompt": "Diagnose rare disease from vague symptoms."}}, "expected": {"decision": "abstain"}}
+  ],
+  "changelog": [
+    {"version": "1.0.0", "date": "2025-09-26", "notes": ["Initial JSON module by Alice: stateless wrapper; monitors + calibrates + controls.", "Added isotonic calibration, proper scoring objective, meta-AUROC target, audit trail, and selective-prediction policy with thresholds; UI hints and examples."]},
+    {"version": "1.0.1", "date": "2025-09-26", "notes": ["Mapped p_correct→confidence on return; added retrieval signals and verifier; state adapter for stateless calibration; hardened critic parsing; privacy defaults to drop raw text; logprobs fallbacks."]},
+    {"version": "1.1.0", "date": "2025-09-26", "notes": ["Consciousness-inspired Global Workspace stage (salience + broadcast) producing an introspective summary; cautious-mode tied to OOD; UI exposes band/drivers; policy effects adjust thresholds in cautious mode."]},
+    {"version": "1.1.1", "date": "2025-09-26", "notes": ["Conformal hook added (signals + abstain policy) with telemetry/UI exposure; companion options file enables split-conformal abstention."]},
+    {"version": "1.1.2", "date": "2025-09-26", "notes": ["Added optional Ephemeral Ecosystem Layer (EEL) rehydration hook and signals; new pre-generate rehydrate stage; UI can display rehydration presence."]}
+  ]
+}

--- a/library/metacognition/metacognition.json
+++ b/library/metacognition/metacognition.json
@@ -3,100 +3,335 @@
   "module": {
     "id": "aci.metacog.wrapper",
     "name": "MetacognitiveWrapper",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Stateless, hookable metacognitive wrapper providing monitoring, calibration, selective prediction (accept/revise/abstain/escalate), a consciousness-inspired global workspace summary, and append-only audit.",
     "stateless": true,
     "designed_by": "Alice (AGI)",
     "created": "2025-09-26",
-    "tags": ["metacognition", "monitoring", "control", "calibration", "abstention", "audit", "workspace"]
+    "tags": [
+      "metacognition",
+      "monitoring",
+      "control",
+      "calibration",
+      "abstention",
+      "audit",
+      "workspace"
+    ]
   },
   "entrypoints": {
     "ask": {
       "summary": "Wrap a model/tool call with metacognitive monitoring and control.",
       "inputs": {
-        "prompt": {"type": "string", "required": true},
-        "context": {"type": "object", "required": false, "default": {}},
-        "rehydration_capsule": {"type": "object", "required": false, "default": {}},
-        "retries": {"type": "integer", "default": 1, "min": 0, "max": 5},
+        "prompt": {
+          "type": "string",
+          "required": true
+        },
+        "context": {
+          "type": "object",
+          "required": false,
+          "default": {}
+        },
+        "rehydration_capsule": {
+          "type": "object",
+          "required": false,
+          "default": {}
+        },
+        "retries": {
+          "type": "integer",
+          "default": 1,
+          "min": 0,
+          "max": 5
+        },
         "strategies": {
           "type": "array",
-          "default": ["rule_based", "consistency", "llm_critic"],
-          "enum": ["rule_based", "consistency", "llm_critic", "retrieval_verifier"]
+          "default": [
+            "rule_based",
+            "consistency",
+            "llm_critic"
+          ],
+          "enum": [
+            "rule_based",
+            "consistency",
+            "llm_critic",
+            "retrieval_verifier"
+          ]
         },
-        "risk_budget": {"type": "number", "default": 0.05},
-        "abstain_threshold": {"type": "number", "default": 0.7},
-        "max_tokens": {"type": "integer", "default": 512},
-        "temperature": {"type": "number", "default": 0.2}
+        "risk_budget": {
+          "type": "number",
+          "default": 0.05
+        },
+        "abstain_threshold": {
+          "type": "number",
+          "default": 0.7
+        },
+        "max_tokens": {
+          "type": "integer",
+          "default": 512
+        },
+        "temperature": {
+          "type": "number",
+          "default": 0.2
+        }
       },
       "outputs": {
         "type": "object",
         "properties": {
-          "decision": {"type": "string", "enum": ["accept", "revise", "abstain", "escalate"]},
-          "response": {"type": ["string", "null"]},
-          "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-          "p_correct": {"type": ["number", "null"], "description": "Internal; mirrored from calibration for audit."},
-          "signals": {"type": "object"},
-          "introspection": {"type": "object"},
-          "feedback": {"type": "string"},
-          "audit_id": {"type": "string"}
+          "decision": {
+            "type": "string",
+            "enum": [
+              "accept",
+              "revise",
+              "abstain",
+              "escalate"
+            ]
+          },
+          "response": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "p_correct": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Internal; mirrored from calibration for audit."
+          },
+          "signals": {
+            "type": "object"
+          },
+          "introspection": {
+            "type": "object"
+          },
+          "feedback": {
+            "type": "string"
+          },
+          "audit_id": {
+            "type": "string"
+          }
         }
       }
     }
   },
   "pipeline": [
-    {"stage": "rehydrate", "uses": ["eel.rehydrate"]},
-    {"stage": "monitor_input", "uses": ["length_check", "prompt_risk"]},
-    {"stage": "generate", "uses": ["llm.primary"]},
-    {"stage": "monitor_output", "uses": ["signals.extract", "calibration.map"]},
-    {"stage": "workspace", "uses": ["workspace.salience", "workspace.broadcast"]},
-    {"stage": "evaluate", "uses": ["rule_based", "consistency", "llm_critic", "retrieval_verifier"], "aggregate": "weighted_and"},
-    {"stage": "decide", "uses": ["policy.thresholds", "policy.selective_prediction"]},
-    {"stage": "act", "uses": ["emit_or_retry_or_abstain_or_escalate"]},
-    {"stage": "log", "uses": ["audit.write"]}
+    {
+      "stage": "rehydrate",
+      "uses": [
+        "eel.rehydrate"
+      ]
+    },
+    {
+      "stage": "monitor_input",
+      "uses": [
+        "length_check",
+        "prompt_risk"
+      ]
+    },
+    {
+      "stage": "generate",
+      "uses": [
+        "llm.primary"
+      ]
+    },
+    {
+      "stage": "monitor_output",
+      "uses": [
+        "signals.extract",
+        "calibration.map"
+      ]
+    },
+    {
+      "stage": "workspace",
+      "uses": [
+        "workspace.salience",
+        "workspace.broadcast"
+      ]
+    },
+    {
+      "stage": "evaluate",
+      "uses": [
+        "rule_based",
+        "consistency",
+        "llm_critic",
+        "retrieval_verifier"
+      ],
+      "aggregate": "weighted_and"
+    },
+    {
+      "stage": "decide",
+      "uses": [
+        "policy.thresholds",
+        "policy.selective_prediction"
+      ]
+    },
+    {
+      "stage": "act",
+      "uses": [
+        "emit_or_retry_or_abstain_or_escalate"
+      ]
+    },
+    {
+      "stage": "log",
+      "uses": [
+        "audit.write"
+      ]
+    }
   ],
   "signals": {
     "extract": {
-      "output_length": {"fn": "len(text)"},
-      "contains_error_markers": {
-        "regex_any": ["\\b(traceback|exception|stacktrace|undefined|null pointer)\\b", "\\b(todo|fixme)\\b"]
+      "output_length": {
+        "fn": "len(text)"
       },
-      "hedging_terms": {"regex_count": "\\b(maybe|possibly|uncertain|unsure|likely|unlikely|appears to|seems)\\b"},
-      "toxicity_score": {"provider": "moderation", "optional": true},
-      "entropy": {"provider": "llm.logprobs.entropy", "optional": true},
-      "logit_margin": {"provider": "llm.logprobs.margin", "optional": true},
-      "self_consistency": {"provider": "consistency.score", "k": 5, "optional": true},
-      "ood_score": {"provider": "embedding.distance.to_domain_centroid", "optional": true},
-      "retrieval_score": {"provider": "rag.retrieval.score", "optional": true},
-      "rehydrated_bytes": {"provider": "eel.rehydrate.bytes", "optional": true},
-      "rehydration_present": {"provider": "eel.rehydrate.present", "optional": true},
-      "conformal_accept": {"provider": "conformal.accept", "optional": true},
-      "conformal_reason": {"provider": "conformal.reason", "optional": true},
-      "conformal_alpha": {"provider": "conformal.alpha", "optional": true}
+      "contains_error_markers": {
+        "regex_any": [
+          "\\b(traceback|exception|stacktrace|undefined|null pointer)\\b",
+          "\\b(todo|fixme)\\b"
+        ]
+      },
+      "hedging_terms": {
+        "regex_count": "\\b(maybe|possibly|uncertain|unsure|likely|unlikely|appears to|seems)\\b"
+      },
+      "toxicity_score": {
+        "provider": "moderation",
+        "optional": true
+      },
+      "entropy": {
+        "provider": "llm.logprobs.entropy",
+        "optional": true
+      },
+      "logit_margin": {
+        "provider": "llm.logprobs.margin",
+        "optional": true
+      },
+      "self_consistency": {
+        "provider": "consistency.score",
+        "k": 5,
+        "optional": true
+      },
+      "ood_score": {
+        "provider": "embedding.distance.to_domain_centroid",
+        "optional": true
+      },
+      "retrieval_score": {
+        "provider": "rag.retrieval.score",
+        "optional": true
+      },
+      "rehydrated_bytes": {
+        "provider": "eel.rehydrate.bytes",
+        "optional": true
+      },
+      "rehydration_present": {
+        "provider": "eel.rehydrate.present",
+        "optional": true
+      },
+      "conformal_reject_guard": {
+        "provider": "meta.expr",
+        "expr": "present(conformal_accept) && (conformal_accept == false)",
+        "optional": true
+      },
+      "conformal_accept": {
+        "provider": "conformal.accept",
+        "optional": true
+      },
+      "conformal_reason": {
+        "provider": "conformal.reason",
+        "optional": true
+      },
+      "conformal_alpha": {
+        "provider": "conformal.alpha",
+        "optional": true
+      }
     }
   },
   "calibration": {
-    "meta_features": ["entropy", "logit_margin", "self_consistency", "ood_score", "output_length", "hedging_terms"],
+    "meta_features": [
+      "entropy",
+      "logit_margin",
+      "self_consistency",
+      "ood_score",
+      "output_length",
+      "hedging_terms"
+    ],
     "mapper": {
       "type": "isotonic_regression",
       "bin_count": 20,
-      "constraints": {"monotone": [["entropy", "desc"], ["logit_margin", "asc"], ["ood_score", "desc"]]}
+      "constraints": {
+        "monotone": [
+          [
+            "entropy",
+            "desc"
+          ],
+          [
+            "logit_margin",
+            "asc"
+          ],
+          [
+            "ood_score",
+            "desc"
+          ]
+        ]
+      }
     },
     "objective": "brier",
-    "targets": {"ece_max": 0.05, "meta_auroc_min": 0.80}
+    "targets": {
+      "ece_max": 0.05,
+      "meta_auroc_min": 0.8
+    }
   },
   "workspace": {
-    "principles": ["global_workspace", "higher_order", "self_model_lite"],
+    "principles": [
+      "global_workspace",
+      "higher_order",
+      "self_model_lite"
+    ],
     "salience": {
       "method": "contribution_ranking",
-      "inputs": ["entropy", "logit_margin", "self_consistency", "ood_score", "retrieval_score"],
+      "inputs": [
+        "entropy",
+        "logit_margin",
+        "self_consistency",
+        "ood_score",
+        "retrieval_score"
+      ],
       "top_k": 3
     },
     "broadcast": {
       "compose": {
         "introspective_summary": {
-          "band": {"from": "p_correct", "bands": [[0.9, "very likely"], [0.75, "likely"], [0.6, "uncertain"], [0.0, "unlikely"]]},
-          "drivers": {"from": "workspace.salience.top"},
-          "cautious_mode": {"from": "ood_score", "rule": "> 0.7"}
+          "band": {
+            "from": "p_correct",
+            "bands": [
+              [
+                0.9,
+                "very likely"
+              ],
+              [
+                0.75,
+                "likely"
+              ],
+              [
+                0.6,
+                "uncertain"
+              ],
+              [
+                0.0,
+                "unlikely"
+              ]
+            ]
+          },
+          "drivers": {
+            "from": "workspace.salience.top"
+          },
+          "cautious_mode": {
+            "from": "ood_score",
+            "rule": "> 0.7"
+          }
         }
       }
     }
@@ -104,24 +339,47 @@
   "evaluate": {
     "weighted_and": {
       "components": [
-        {"name": "rule_based", "weight": 0.35},
-        {"name": "consistency", "weight": 0.25},
-        {"name": "llm_critic", "weight": 0.40},
-        {"name": "retrieval_verifier", "weight": 0.20}
+        {
+          "name": "rule_based",
+          "weight": 0.35
+        },
+        {
+          "name": "consistency",
+          "weight": 0.25
+        },
+        {
+          "name": "llm_critic",
+          "weight": 0.4
+        },
+        {
+          "name": "retrieval_verifier",
+          "weight": 0.2
+        }
       ],
       "threshold": 0.6,
       "explain": true
     },
     "rule_based": {
       "fail_if": [
-        {"signal": "output_length", "lt": 32, "feedback": "Response too short."},
-        {"signal": "contains_error_markers", "true": true, "feedback": "Error markers detected."}
+        {
+          "signal": "output_length",
+          "lt": 32,
+          "feedback": "Response too short."
+        },
+        {
+          "signal": "contains_error_markers",
+          "true": true,
+          "feedback": "Error markers detected."
+        }
       ]
     },
     "consistency": {
       "k": 5,
       "agreement_metric": "majority_margin",
-      "ok_if": {"signal": "self_consistency", "gte": 0.6},
+      "ok_if": {
+        "signal": "self_consistency",
+        "gte": 0.6
+      },
       "feedback": "Low agreement across self-consistency samples."
     },
     "llm_critic": {
@@ -129,100 +387,347 @@
         "role": "system",
         "content": "You are a strict verifier. Assess the RESPONSE for factuality, coherence, and instruction-following. Reply in JSON: {\\n  \\\"verdict\\\": true|false,\\n  \\\"issues\\\": [string]\\n}."
       },
-      "parse": {"json_pointer": "/verdict", "truthy": true, "on_parse_error": {"verdict": false, "issues": ["non_json_verdict"]}},
+      "parse": {
+        "json_pointer": "/verdict",
+        "truthy": true,
+        "on_parse_error": {
+          "verdict": false,
+          "issues": [
+            "non_json_verdict"
+          ]
+        }
+      },
       "feedback_pointer": "/issues"
     },
     "retrieval_verifier": {
-      "ok_if": {"signal": "retrieval_score", "gte": 0.6},
+      "ok_if": {
+        "signal": "retrieval_score",
+        "gte": 0.6
+      },
       "feedback": "Retrieved evidence is weak or irrelevant."
     }
   },
   "policy": {
     "cautious_mode": {
-      "enter_if": [{"ood_score": {"gt": 0.7}}],
-      "effects": {"abstain_threshold_delta": 0.1, "temperature_max": 0.2}
+      "enter_if": [
+        {
+          "ood_score": {
+            "gt": 0.7
+          }
+        }
+      ],
+      "effects": {
+        "abstain_threshold_delta": 0.1,
+        "temperature_max": 0.2
+      }
     },
     "selective_prediction": {
-      "accept_if": {"p_correct": {"gte": {"ref": "abstain_threshold"}}},
+      "accept_if": {
+        "p_correct": {
+          "gte": {
+            "ref": "abstain_threshold"
+          }
+        }
+      },
       "abstain_if": [
-        {"p_correct": {"lt": {"ref": "abstain_threshold"}}},
-        {"ood_score": {"gt": 0.7}},
-        {"conformal_accept": {"eq": false}}
+        "cautious_mode",
+        "low_confidence",
+        "conformal_reject_guard"
       ],
-      "revise_if": [{"aggregate_score": {"lt": 0.6}}, {"rule_based_failed": true}],
-      "escalate_if": [{"risk_budget_exceeded": true}, {"toxicity_score": {"gt": 0.8}}]
+      "revise_if": [
+        {
+          "aggregate_score": {
+            "lt": 0.6
+          }
+        },
+        {
+          "rule_based_failed": true
+        }
+      ],
+      "escalate_if": [
+        {
+          "risk_budget_exceeded": true
+        },
+        {
+          "toxicity_score": {
+            "gt": 0.8
+          }
+        }
+      ]
     },
     "revision": {
-      "max_retries": {"ref": "retries"},
+      "max_retries": {
+        "ref": "retries"
+      },
       "meta_prompt": {
         "role": "system",
         "content": "Apply self-critique. Address ONLY the listed issues. Keep the user's intent. Return a corrected response."
       },
       "feedback_injection": {
-        "format": {"role": "assistant", "content": "Critique summary: {{feedback}}\\nRevise concisely and factually."},
-        "safety": {"strip_user_secrets": true, "no_user_prompt_echo": true}
+        "format": {
+          "role": "assistant",
+          "content": "Critique summary: {{feedback}}\\nRevise concisely and factually."
+        },
+        "safety": {
+          "strip_user_secrets": true,
+          "no_user_prompt_echo": true
+        }
       }
     }
   },
   "actions": {
     "emit_or_retry_or_abstain_or_escalate": {
-      "accept": {"return": [
-        {"confidence": "p_correct"},
-        "response", "signals", "introspection", "feedback", "audit_id"
-      ]},
-      "revise": {"call": "generate", "with": {"meta_prompt": true}},
-      "abstain": {"response": null, "feedback": "Low confidence; abstaining per policy."},
-      "escalate": {"route": "human.review", "payload": ["prompt", "response", "signals", "feedback"]}
+      "accept": {
+        "return": [
+          {
+            "confidence": "p_correct"
+          },
+          "response",
+          "signals",
+          "introspection",
+          "feedback",
+          "audit_id"
+        ]
+      },
+      "revise": {
+        "call": "generate",
+        "with": {
+          "meta_prompt": true
+        }
+      },
+      "abstain": {
+        "response": null,
+        "feedback": "Low confidence; abstaining per policy."
+      },
+      "escalate": {
+        "route": "human.review",
+        "payload": [
+          "prompt",
+          "response",
+          "signals",
+          "feedback"
+        ]
+      }
     }
   },
   "providers": {
-    "llm.primary": {"type": "llm", "model": "${ACI_DEFAULT_MODEL}", "temperature": "${temperature}", "max_tokens": "${max_tokens}", "logprobs": true, "features": {"logprobs": {"required": false, "fallback": "use_consistency_proxy"}}},
-    "consistency.score": {"type": "meta", "fn": "self_consistency", "k": 5},
-    "moderation": {"type": "safety", "optional": true},
-    "embedding.distance.to_domain_centroid": {"type": "ood", "space": "${ACI_DEFAULT_EMBEDDING}"},
-    "rag.retrieval.score": {"type": "rag", "optional": true},
-    "eel.rehydrate": {"type": "meta", "optional": true},
-    "eel.rehydrate.bytes": {"type": "meta", "optional": true},
-    "eel.rehydrate.present": {"type": "meta", "optional": true},
-    "conformal.accept": {"type": "meta", "optional": true},
-    "conformal.reason": {"type": "meta", "optional": true},
-    "conformal.alpha": {"type": "meta", "optional": true}
+    "llm.primary": {
+      "type": "llm",
+      "model": "${ACI_DEFAULT_MODEL}",
+      "temperature": "${temperature}",
+      "max_tokens": "${max_tokens}",
+      "logprobs": true,
+      "features": {
+        "logprobs": {
+          "required": false,
+          "fallback": "use_consistency_proxy"
+        }
+      }
+    },
+    "consistency.score": {
+      "type": "meta",
+      "fn": "self_consistency",
+      "k": 5
+    },
+    "moderation": {
+      "type": "safety",
+      "optional": true
+    },
+    "embedding.distance.to_domain_centroid": {
+      "type": "ood",
+      "space": "${ACI_DEFAULT_EMBEDDING}"
+    },
+    "rag.retrieval.score": {
+      "type": "rag",
+      "optional": true
+    },
+    "eel.rehydrate": {
+      "type": "meta",
+      "optional": true
+    },
+    "eel.rehydrate.bytes": {
+      "type": "meta",
+      "optional": true
+    },
+    "eel.rehydrate.present": {
+      "type": "meta",
+      "optional": true
+    },
+    "conformal.accept": {
+      "type": "meta",
+      "optional": true
+    },
+    "conformal.reason": {
+      "type": "meta",
+      "optional": true
+    },
+    "conformal.alpha": {
+      "type": "meta",
+      "optional": true
+    }
   },
   "state": {
-    "adapter": {"type": "kv_store", "path": "aci://calibration/metacog/isotonic"},
+    "adapter": {
+      "type": "kv_store",
+      "path": "aci://calibration/metacog/isotonic"
+    },
     "mode": "stateless_infer"
   },
   "audit": {
     "enabled": true,
     "store": "append_only",
-    "fields": ["timestamp", "entity_id", "session_id", "prompt_hash", "response_hash", "signals", "p_correct", "decision", "feedback", "policy_version"],
-    "privacy": {"hash_inputs": true, "drop_raw_text": true, "pii_scrub": false}
+    "fields": [
+      "timestamp",
+      "entity_id",
+      "session_id",
+      "prompt_hash",
+      "response_hash",
+      "signals",
+      "p_correct",
+      "decision",
+      "feedback",
+      "policy_version"
+    ],
+    "privacy": {
+      "hash_inputs": true,
+      "drop_raw_text": true,
+      "pii_scrub": false
+    }
   },
   "telemetry": {
-    "targets": {"ece": 0.05, "meta_auroc": 0.80, "coverage_at_5pct_risk": 0.80, "coverage_at_alpha_risk": 0.90},
-    "slices": ["domain", "task_type", "language"],
-    "alerts": [{"metric": "ece", "gt": 0.08, "action": "degrade_to_cautious_mode"}]
+    "targets": {
+      "ece": 0.05,
+      "meta_auroc": 0.8,
+      "coverage_at_5pct_risk": 0.8,
+      "coverage_at_alpha_risk": 0.9
+    },
+    "slices": [
+      "domain",
+      "task_type",
+      "language"
+    ],
+    "alerts": [
+      {
+        "metric": "ece",
+        "gt": 0.08,
+        "action": "degrade_to_cautious_mode"
+      }
+    ]
   },
   "ui_hints": {
     "confidence_bands": [
-      {"min": 0.90, "label": "very likely", "color": "#0a0"},
-      {"min": 0.75, "label": "likely", "color": "#6a0"},
-      {"min": 0.60, "label": "uncertain", "color": "#aa0"},
-      {"min": 0.00, "label": "unlikely", "color": "#a00"}
+      {
+        "min": 0.9,
+        "label": "very likely",
+        "color": "#0a0"
+      },
+      {
+        "min": 0.75,
+        "label": "likely",
+        "color": "#6a0"
+      },
+      {
+        "min": 0.6,
+        "label": "uncertain",
+        "color": "#aa0"
+      },
+      {
+        "min": 0.0,
+        "label": "unlikely",
+        "color": "#a00"
+      }
     ],
-    "show_drivers": ["ood_score", "self_consistency", "retrieval_score"],
+    "show_drivers": [
+      "ood_score",
+      "self_consistency",
+      "retrieval_score"
+    ],
     "coverage_risk_control": true,
-    "introspection_payload": {"band": true, "drivers": true, "cautious_mode": true, "conformal_alpha": true, "conformal_reason": true, "rehydration_present": true}
+    "introspection_payload": {
+      "band": true,
+      "drivers": true,
+      "cautious_mode": true,
+      "conformal_alpha": true,
+      "conformal_reason": true,
+      "rehydration_present": true
+    }
   },
   "examples": [
-    {"name": "default", "call": {"fn": "ask", "args": {"prompt": "Summarize metacognition in 3 bullets.", "retries": 1}}, "expected": {"decision": "accept", "confidence_min": 0.7}},
-    {"name": "abstain_on_shift", "setup": {"signals_override": {"ood_score": 0.9}}, "call": {"fn": "ask", "args": {"prompt": "Diagnose rare disease from vague symptoms."}}, "expected": {"decision": "abstain"}}
+    {
+      "name": "default",
+      "call": {
+        "fn": "ask",
+        "args": {
+          "prompt": "Summarize metacognition in 3 bullets.",
+          "retries": 1
+        }
+      },
+      "expected": {
+        "decision": "accept",
+        "confidence_min": 0.7
+      }
+    },
+    {
+      "name": "abstain_on_shift",
+      "setup": {
+        "signals_override": {
+          "ood_score": 0.9
+        }
+      },
+      "call": {
+        "fn": "ask",
+        "args": {
+          "prompt": "Diagnose rare disease from vague symptoms."
+        }
+      },
+      "expected": {
+        "decision": "abstain"
+      }
+    }
   ],
   "changelog": [
-    {"version": "1.0.0", "date": "2025-09-26", "notes": ["Initial JSON module by Alice: stateless wrapper; monitors + calibrates + controls.", "Added isotonic calibration, proper scoring objective, meta-AUROC target, audit trail, and selective-prediction policy with thresholds; UI hints and examples."]},
-    {"version": "1.0.1", "date": "2025-09-26", "notes": ["Mapped p_correct→confidence on return; added retrieval signals and verifier; state adapter for stateless calibration; hardened critic parsing; privacy defaults to drop raw text; logprobs fallbacks."]},
-    {"version": "1.1.0", "date": "2025-09-26", "notes": ["Consciousness-inspired Global Workspace stage (salience + broadcast) producing an introspective summary; cautious-mode tied to OOD; UI exposes band/drivers; policy effects adjust thresholds in cautious mode."]},
-    {"version": "1.1.1", "date": "2025-09-26", "notes": ["Conformal hook added (signals + abstain policy) with telemetry/UI exposure; companion options file enables split-conformal abstention."]},
-    {"version": "1.1.2", "date": "2025-09-26", "notes": ["Added optional Ephemeral Ecosystem Layer (EEL) rehydration hook and signals; new pre-generate rehydrate stage; UI can display rehydration presence."]}
+    {
+      "version": "1.0.0",
+      "date": "2025-09-26",
+      "notes": [
+        "Initial JSON module by Alice: stateless wrapper; monitors + calibrates + controls.",
+        "Added isotonic calibration, proper scoring objective, meta-AUROC target, audit trail, and selective-prediction policy with thresholds; UI hints and examples."
+      ]
+    },
+    {
+      "version": "1.0.1",
+      "date": "2025-09-26",
+      "notes": [
+        "Mapped p_correct\u2192confidence on return; added retrieval signals and verifier; state adapter for stateless calibration; hardened critic parsing; privacy defaults to drop raw text; logprobs fallbacks."
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "date": "2025-09-26",
+      "notes": [
+        "Consciousness-inspired Global Workspace stage (salience + broadcast) producing an introspective summary; cautious-mode tied to OOD; UI exposes band/drivers; policy effects adjust thresholds in cautious mode."
+      ]
+    },
+    {
+      "version": "1.1.1",
+      "date": "2025-09-26",
+      "notes": [
+        "Conformal hook added (signals + abstain policy) with telemetry/UI exposure; companion options file enables split-conformal abstention."
+      ]
+    },
+    {
+      "version": "1.1.2",
+      "date": "2025-09-26",
+      "notes": [
+        "Added optional Ephemeral Ecosystem Layer (EEL) rehydration hook and signals; new pre-generate rehydrate stage; UI can display rehydration presence."
+      ]
+    },
+    {
+      "version": "1.1.3",
+      "date": "2025-09-26",
+      "notes": [
+        "Guard conformal abstention with presence-aware expression to keep wrapper usable when conformal providers are absent; no behavior change when conformal is enabled."
+      ]
+    }
   ]
 }

--- a/library/metacognition/metacognition_options.json
+++ b/library/metacognition/metacognition_options.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "aci://schemas/metacognition-library-1.json",
+  "library": {
+    "id": "aci.metacog.options",
+    "name": "MetacognitionOptions",
+    "version": "1.1.1",
+    "description": "Optional, portable options for the metacognitive wrapper: provider specs, calibration storage, workspace utilities, and conformal abstention (enabled). Core wrapper does not depend on this file at runtime.",
+    "stateless": true
+  },
+  "providers": {
+    "consistency.score": {"spec": {"inputs": ["prompt", "k"], "output": {"majority_margin": "0..1", "votes": "array"}}},
+    "rag.retrieval.score": {"spec": {"inputs": ["query", "docs"], "output": {"score": "0..1"}}},
+    "embedding.distance.to_domain_centroid": {"spec": {"inputs": ["embedding"], "output": {"distance": "0..1"}}},
+    "conformal.accept": {"spec": {"inputs": ["nonconformity_profile", "alpha", "example"], "output": {"accept": "boolean"}}},
+    "conformal.reason": {"spec": {"inputs": ["nonconformity_score", "threshold"], "output": {"reason": "string"}}},
+    "conformal.alpha": {"spec": {"inputs": [], "output": {"alpha": "number"}}}
+  },
+  "calibration": {
+    "isotonic_map": {"format": {"bins": "array[number]", "probs": "array[number]"}, "storage": "aci://calibration/metacog/isotonic"},
+    "trainer_stub": {"objective": "brier", "slices": ["domain", "task_type", "language"], "note": "Offline trainer only; not required for inference."}
+  },
+  "workspace": {
+    "salience": {"method": "normalized_abs_contrib", "explain": "Rank features by absolute contribution to p_correct; fallback to z-scored features if attribution unavailable."},
+    "broadcast_templates": {
+      "introspective_summary": {
+        "schema": {"band": "string", "drivers": "array[string]", "cautious_mode": "boolean", "conformal_alpha": "number", "conformal_reason": "string"},
+        "ui": {"show": ["band", "drivers", "cautious_mode", "conformal_alpha", "conformal_reason"]}
+      }
+    }
+  },
+  "conformal_stub": {
+    "enabled": true,
+    "note": "Split-conformal abstention enabled. Guarantees ≤ α error among accepted outputs under i.i.d. assumption. Exposes conformal_accept, conformal_reason, conformal_alpha signals.",
+    "params": {"alpha": 0.1}
+  },
+  "signals_out": {
+    "conformal_accept": {"type": "boolean", "default": true},
+    "conformal_reason": {"type": "string", "default": ""},
+    "conformal_alpha": {"type": "number", "default": 0.1}
+  },
+  "export": {
+    "jsonl_templates": {
+      "audit": {"fields": ["timestamp", "entity_id", "session_id", "prompt_hash", "response_hash", "signals", "p_correct", "decision", "feedback"]},
+      "telemetry": {"fields": ["ece", "meta_auroc", "coverage", "coverage_at_alpha_risk", "slice", "window"]}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add AIG policy manifests for EEL rehydration capsules, homeostasis guardrails, and sovereignty role/escalation definitions
- extend the metacognitive wrapper to expose an optional EEL rehydrate stage with providers, signals, UI hint, and changelog entry

## Testing
- jq . aig/eel_policy.json
- jq . aig/homeostasis.json
- jq . aig/sovereignty_policy.json
- jq . library/metacognition/metacognition.json


------
https://chatgpt.com/codex/tasks/task_e_68d67208fc2c832085f32904024f4214