### PR TITLE
Ensure timestamp normalization returns canonical form

### DIFF
--- a/entities/agi/agi_tools/migrate_to_jsonl/migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/migrate.py
@@ -260,14 +260,16 @@ def normalize_timestamp(
         parsed = parsed.replace(tzinfo=dt.timezone.utc)
 
     parsed_utc = parsed.astimezone(dt.timezone.utc)
+    canonical = parsed_utc.isoformat().replace("+00:00", "Z")
 
     if timestamp_value and had_z:
         original = timestamp_value.strip()
         if original.endswith("z"):
             original = original[:-1] + "Z"
-        return original
+        if original == canonical:
+            return original
 
-    return parsed_utc.isoformat().replace("+00:00", "Z")
+    return canonical
 
 
 def normalize_content(message: Dict[str, Any]) -> str:

--- a/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
@@ -14,6 +14,13 @@ class NormalizeTimestampTests(unittest.TestCase):
             "2023-05-05T12:34:56Z",
         )
 
+    def test_normalizes_space_separated_z_timestamp(self) -> None:
+        message = {"timestamp": "2023-05-05 15:00:00Z"}
+        self.assertEqual(
+            migrate.normalize_timestamp(message),
+            "2023-05-05T15:00:00Z",
+        )
+
     def test_converts_offset_to_utc(self) -> None:
         message = {"timestamp": "2023-05-05T12:34:56+02:00"}
         self.assertEqual(


### PR DESCRIPTION
## Summary
- adjust normalize_timestamp to always compute a canonical UTC string and only return the original value when it already matches that canonical form
- extend NormalizeTimestampTests to cover space-separated timestamps ending in Z

## Testing
- python -m unittest entities.agi.agi_tools.migrate_to_jsonl.test_migrate

------
https://chatgpt.com/codex/tasks/task_e_68d71a31aa148320bca74e897120e5ca