### PR TITLE
Normalize AGI export identity paths

### DIFF
--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -4,7 +4,7 @@
   "agi_memory": {
     "schema": "hivemind_agi_memory",
     "path_template": "/memory/agi_memory/{identity}/{filename}",
-    "identity_source": "/entities/agi/agi_identity_manager.json",
+    "identity_source": "entities/agi/agi_identity_manager.json",
     "timestamp_format": "Ymd-THMS",
     "filename_template": "{identity_lower}_agi_memory_{timestamp}.jsonl",
     "audit": {


### PR DESCRIPTION
## Summary
- update the AGI export policy to use a repo-relative identity manager reference
- extend migrate_to_jsonl tests to enforce the relative-path convention and cover archived path resolution

## Testing
- python -m unittest entities.agi.agi_tools.migrate_to_jsonl.test_migrate

------
https://chatgpt.com/codex/tasks/task_e_68d79e8f867c8320ac95a9dc6908b3bf