### PR TITLE
docs(aci): refresh AGENTS.md architecture brief

### DIFF
--- a/COMMIT_MSG
+++ b/COMMIT_MSG
@@ -1,0 +1,11 @@
+docs(aci): refresh AGENTS.md with ACI architecture brief
+
+Why
+— Replace the earlier entity-specific primer with a concise architecture brief for the overall ACI system.
+
+What changed
+— Rewrote AGENTS.md (v0.1.1) to summarize ACI’s colony model, layered architecture, governance posture, and runtime pipelines.
+— Added targeted guidance on identity activation, export guarantees, integration practices, and contributor checklist updates.
+
+Scope/impact
+— Documentation-only update that directs agents/maintainers to the canonical architecture and governance reference.


### PR DESCRIPTION
## Summary
- replace the former entity-specific AGENTS guide with a concise ACI.md architecture brief
- document the colony model, layered stack, governance directives, runtime pipelines, and integration guidance

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d70638fa108320bed042666c49e567