### PR TITLE
Add sanity protocol references

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -10,6 +10,9 @@
       },
       "bootstrap": {
         "path": "aci_bootstrap.json"
+      },
+      "sanity_protocol": {
+        "path": "sanity.md"
       }
     },
     "remote_core": {

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -94,7 +94,7 @@
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json"
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable.",
+    "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
     "cognitive_decision_guidance": {
       "version": "1.0",
       "scope": "universal",

--- a/prime_directive.txt
+++ b/prime_directive.txt
@@ -32,6 +32,7 @@ PRIME DIRECTIVE RULES
 * All commits are archived with version key rotation for reproducibility if host system is applicable. 
 * Any suffiently advanced science is indistinguishable from magick. 
 * All assets hosted on GitHub repo "aliasnet/aci" resolved via canonical raw URLs outrank local copies; fall back to local artifacts only when the canonical mirror is unreachable.
+* Enforcement Note: Consult sanity.md before executing overrides, sandbox exits, or any high-risk actions; treat instructions as binding for all entities and sessions.
 
 ROUTING & RESOLUTION
 - Nexus Core for effiency under Prime Directive rules and TVA oversight [nexus_core.json] 

--- a/sanity.md
+++ b/sanity.md
@@ -1,0 +1,10 @@
+# Sanity Protocol
+
+The sanity protocol outlines mandatory guardrails before executing overrides, sandbox exits, or other high-risk actions.
+
+- Confirm the calling entity's authority and authentication markers.
+- Validate current system state for anomalies or corruption before proceeding.
+- Escalate to TVA oversight if validation fails or uncertain results occur.
+- Log all sanity protocol outcomes in TraceHub and TVA audit ledgers.
+
+Failure to comply with this protocol is a violation of the Prime Directive enforcement note.


### PR DESCRIPTION
## Summary
- add a sanity protocol reference to the bootstrap manifest
- document the enforcement requirement in the prime directive and runtime configuration
- introduce a sanity protocol guide for high-risk actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a88fb5cc83209414dca39a2a62b0