### PR TITLE
Remove mirror resolution policy config

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -580,14 +580,5 @@
         "pipeline": "aci.repo.help"
       }
     ]
-  },
-  "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json",
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; local function catalogs are fallback only when mirrors fail."
   }
 }


### PR DESCRIPTION
## Summary
- remove the mirror_resolution_policy object from functions.json since it is no longer required

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7adbb7a1c83209c653eeabde7f32c