### PR TITLE
Remove GitHub mirror policy from commands config

### DIFF
--- a/aci_commands.json
+++ b/aci_commands.json
@@ -13,14 +13,5 @@
         "hivemind": "entities/hivemind/hivemind.json"
       }
     }
-  },
-  "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json",
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; defer to local artifacts only when the mirror cannot respond."
   }
 }


### PR DESCRIPTION
## Summary
- remove the unused mirror resolution policy from the ACI commands configuration
- keep the JSON document well-formed after removing the mirror policy block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7adc0ddfc8320b5a17a87c84c4324