### PR TITLE
Remove mirror resolution policy configuration

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -217,14 +217,5 @@
         "file": "pmu_adapter.json"
       }
     ]
-  },
-  "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json",
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; fall back to local entity manifests only when mirrors fail."
   }
 }


### PR DESCRIPTION
## Summary
- remove the deprecated `mirror_resolution_policy` entry from `entities.json` now that the GitHub resolver reference is no longer required

## Testing
- jq empty entities.json

------
https://chatgpt.com/codex/tasks/task_e_68d7adc15c588320811c583a78d55b3c