### PR TITLE
Remove mirror resolution policy from alias registry

### DIFF
--- a/alias.json
+++ b/alias.json
@@ -43,14 +43,5 @@
       "tva": "enforces anomaly control and runtime authority",
       "mother": "serves as governance interface"
     }
-  },
-  "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json",
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; use local registry data only if the mirror is unreachable."
   }
 }


### PR DESCRIPTION
## Summary
- remove the mirror_resolution_policy entry from alias.json so only the local registry remains

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7adc8cf648320bc1bda775f4dec94