### PR TITLE
Remove mirror resolution policy from bootstrap config

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -62,14 +62,5 @@
       "notes": "If promotion criteria not met, do not continue to full bootstrap; start sandbox and emit alert."
     },
     "notes": "Manifest enforces preflight promotion check. If promotion fails, runtime enters sandbox and waits (with retries) before final decision."
-  },
-  "mirror_resolution_policy": {
-    "key": "aci_github_resolver",
-    "file": "aci_github_resolver.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json",
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; use local files only if the mirror cannot be reached."
   }
 }


### PR DESCRIPTION
## Summary
- remove the mirror_resolution_policy entry from aci_bootstrap.json so the configuration only references local bootstrap data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7adca44908320aa49ff5465075eef