### PR TITLE
Remove mirror resolution policy from runtime configuration

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -86,13 +86,6 @@
       "priority": 85,
       "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
     },
-    "mirror_resolution_policy": {
-      "key": "aci_github_resolver",
-      "file": "aci_github_resolver.json",
-      "canonical_source": "github",
-      "repo": "aliasnet/aci",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json"
-    },
     "priority": "canonical_raw_over_local",
     "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
     "cognitive_decision_guidance": {


### PR DESCRIPTION
## Summary
- remove the `mirror_resolution_policy` object from `aci_runtime.json`
- drop the GitHub resolver reference tied to that policy entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7adcc2b5483209a318cf8efb18c18