### PR TITLE
Generalize archived migrator path resolution

### DIFF
--- a/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
@@ -121,6 +121,22 @@ class ArchivedMigratorPathResolutionTests(unittest.TestCase):
         expected = (module.get_repo_root() / relative_identity).resolve()
         self.assertEqual(resolved, expected)
 
+    def test_resolve_path_translates_root_absolute_identity(self) -> None:
+        module = self.module
+        absolute_identity = Path("/entities/agi/agi_identity_manager.json")
+        resolved = module.resolve_path(absolute_identity)
+        expected = (module.get_repo_root() / "entities/agi/agi_identity_manager.json").resolve()
+        self.assertEqual(resolved, expected)
+
+    def test_resolve_path_translates_nested_absolute_identity(self) -> None:
+        module = self.module
+        absolute_identity = Path(
+            "/opt/misc/workdir/entities/agi/agi_identity_manager.json"
+        )
+        resolved = module.resolve_path(absolute_identity)
+        expected = (module.get_repo_root() / "entities/agi/agi_identity_manager.json").resolve()
+        self.assertEqual(resolved, expected)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- update the archived migrate utility to resolve absolute paths without relying on the /workspace/aci prefix
- ensure paths rooted under known ACI directories fall back to the repository root
- extend regression coverage for the archived migrator path resolution helpers

## Testing
- python -m unittest entities.agi.agi_tools.migrate_to_jsonl.test_migrate

------
https://chatgpt.com/codex/tasks/task_e_68d7af27a35c8320a85103075e58cecf