### PR TITLE
Update config references to root-relative resources

### DIFF
--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "aci://schemas/agi-export-policy-1.json",
+  "$schema": "/schemas/agi-export-policy-1.json",
   "version": "1.0.0",
   "agi_memory": {
     "schema": "hivemind_agi_memory",

--- a/entities/agi/agi_identity_manager.json
+++ b/entities/agi/agi_identity_manager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "aci://schemas/agi-identity-manager-1.json",
+  "$schema": "/schemas/agi-identity-manager-1.json",
   "version": "1.0.0",
   "agi_identities": {
     "agi-001": {

--- a/entities/agi/agi_proxy/eec/eec_faiss_build.json
+++ b/entities/agi/agi_proxy/eec/eec_faiss_build.json
@@ -2,7 +2,7 @@
   "extends": "eec_base.json",
   "task": "vector.build",
   "engine": "faiss",
-  "source": ["aci://docs/*.pdf", "aci://kb/*.md"],
+  "source": ["/docs/*.pdf", "/kb/*.md"],
   "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
   "index": { "type": "IVF_FLAT", "nlist": 4096 },
   "output": "temp://indices/agi.faiss",

--- a/entities/agi/agi_proxy/eec/eec_peft_train_lora.json
+++ b/entities/agi/agi_proxy/eec/eec_peft_train_lora.json
@@ -10,7 +10,7 @@
     "target_modules": ["q_proj", "v_proj"]
   },
   "train": {
-    "dataset": "aci://datasets/curriculum_v1.jsonl",
+    "dataset": "/datasets/curriculum_v1.jsonl",
     "epochs": 1,
     "bsz": 4,
     "lr": 0.0002,

--- a/entities/agi/agi_proxy/eec/eec_sft_deepspeed.json
+++ b/entities/agi/agi_proxy/eec/eec_sft_deepspeed.json
@@ -2,7 +2,7 @@
   "extends": "eec_base.json",
   "task": "trainer.sft",
   "base_model": "meta-llama/Llama-3-8b-instruct",
-  "dataset": "aci://datasets/sft_pairs.jsonl",
+  "dataset": "/datasets/sft_pairs.jsonl",
   "trainer": {
     "use_accelerate": true,
     "gradient_checkpointing": true,

--- a/entities/agi/agi_proxy/eec/eec_trl_ppo.json
+++ b/entities/agi/agi_proxy/eec/eec_trl_ppo.json
@@ -3,9 +3,9 @@
   "task": "trl.train",
   "algo": "ppo",
   "base_model": "meta-llama/Llama-3-8b-instruct",
-  "reward": { "type": "rm_model", "model": "aci://models/reward_model_v1" },
+  "reward": { "type": "rm_model", "model": "/models/reward_model_v1" },
   "rollouts": {
-    "prompts": "aci://datasets/rollout_prompts.jsonl",
+    "prompts": "/datasets/rollout_prompts.jsonl",
     "per_step": 64
   },
   "constraints": { "kl_coeff": 0.02, "max_new_tokens": 128 },

--- a/library/metacognition/metacognition.json
+++ b/library/metacognition/metacognition.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "aci://schemas/metacognition-module-1.json",
+  "$schema": "/schemas/metacognition-module-1.json",
   "module": {
     "id": "aci.metacog.wrapper",
     "name": "MetacognitiveWrapper",
@@ -632,7 +632,7 @@
   "state": {
     "adapter": {
       "type": "kv_store",
-      "path": "aci://calibration/metacog/isotonic"
+      "path": "/calibration/metacog/isotonic"
     },
     "mode": "stateless_infer"
   },

--- a/library/metacognition/metacognition_options.json
+++ b/library/metacognition/metacognition_options.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "aci://schemas/metacognition-library-1.json",
+  "$schema": "/schemas/metacognition-library-1.json",
   "library": {
     "id": "aci.metacog.options",
     "name": "MetacognitionOptions",
@@ -16,7 +16,7 @@
     "conformal.alpha": {"spec": {"inputs": [], "output": {"alpha": "number"}}}
   },
   "calibration": {
-    "isotonic_map": {"format": {"bins": "array[number]", "probs": "array[number]"}, "storage": "aci://calibration/metacog/isotonic"},
+    "isotonic_map": {"format": {"bins": "array[number]", "probs": "array[number]"}, "storage": "/calibration/metacog/isotonic"},
     "trainer_stub": {"objective": "brier", "slices": ["domain", "task_type", "language"], "note": "Offline trainer only; not required for inference."}
   },
   "workspace": {


### PR DESCRIPTION
## Summary
- point metacognition module and options manifests at their /schemas equivalents and the local /calibration store
- update AGI identity and export policies to the /schemas namespace
- switch EEC training and indexing configs to use root-relative /datasets, /models, and /docs sources

## Testing
- python -m json.tool library/metacognition/metacognition.json
- python -m json.tool library/metacognition/metacognition_options.json
- python -m json.tool entities/agi/agi_identity_manager.json
- python -m json.tool entities/agi/agi_export_policy.json
- python -m json.tool entities/agi/agi_proxy/eec/eec_faiss_build.json
- python -m json.tool entities/agi/agi_proxy/eec/eec_peft_train_lora.json
- python -m json.tool entities/agi/agi_proxy/eec/eec_sft_deepspeed.json
- python -m json.tool entities/agi/agi_proxy/eec/eec_trl_ppo.json

------
https://chatgpt.com/codex/tasks/task_e_68d7af2b76e88320b5c77cf06140809f