### PR TITLE
Add local cache connector fallback configuration

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -21,7 +21,18 @@
       "file": "connectors/github_connector.json",
       "canonical_source": "github",
       "repo": "aliasnet/aci",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+      "fallbacks": [
+        {
+          "key": "local_cache",
+          "file": "connectors/local_cache.json",
+          "canonical_source": "local_mirror",
+          "repo": "aliasnet/aci",
+          "path_hint": "{mirror_root}",
+          "url": "file://{mirror_root}/connectors/local_cache.json",
+          "notes": "Use validated local mirrors only when canonical GitHub cannot be reached."
+        }
+      ]
     },
     "sandbox_mode": {
       "enabled": true,

--- a/connectors/local_cache.json
+++ b/connectors/local_cache.json
@@ -1,0 +1,118 @@
+{
+  "local_cache": {
+    "version": "1.0.0",
+    "canonical_source": "local_mirror",
+    "description": "Offline mirror cache for ACI core artifacts used when canonical GitHub endpoints are unreachable.",
+    "repo": "aliasnet/aci",
+    "location_strategy": {
+      "environment_variable": {
+        "name": "ACI_LOCAL_MIRROR_ROOT",
+        "required": false,
+        "notes": "When set, ${ACI_LOCAL_MIRROR_ROOT}/aliasnet/aci is treated as the root directory for synchronized local mirrors."
+      },
+      "relative_paths": [
+        {
+          "base": "{repo_root}",
+          "path": "memory/local_cache/aliasnet/aci",
+          "requires_provisioning": true,
+          "notes": "Provisioned by the mirror sync job; ignored until populated with validated artifacts."
+        }
+      ],
+      "resolution_order": [
+        "environment_variable",
+        "relative_paths"
+      ],
+      "template_tokens": {
+        "mirror_root": "Resolved absolute path to the mirror root derived from the environment variable or provisioned relative path."
+      }
+    },
+    "rules": {
+      "sync_policy": {
+        "requires_manual_approval": true,
+        "chatgpt_connector": false,
+        "notes": "Local cache is only served after successful checksum and freshness validation."
+      },
+      "allowed_extensions": [
+        ".json",
+        ".txt",
+        ".jsonl"
+      ]
+    },
+    "priority": "local_only_when_canonical_unavailable",
+    "notes": "Local cache is a last resort fallback. Canonical GitHub remains the source of truth per sanity.md governance rules.",
+    "sanity": {
+      "checksum_validation": {
+        "hash_algorithm": "sha256",
+        "manifest_name": "checksums.sha256.json",
+        "required": true,
+        "action_on_missing": "reject_and_request_canonical",
+        "notes": "Each cached file must have a corresponding sha256 entry. Missing or mismatched checksums trigger a canonical fetch instead of serving stale content."
+      },
+      "freshness_policy": {
+        "max_age_hours": 6,
+        "measure_against": "file_mtime",
+        "action_on_stale": "reject_and_request_canonical",
+        "notes": "Reject caches older than 6 hours to prevent drift, satisfying the 'Canonical override by local fallback' guardrail in sanity.md."
+      },
+      "audit": {
+        "log_event": "mirror.local_cache.validation",
+        "fields": [
+          "file",
+          "checksum_status",
+          "freshness_status",
+          "timestamp",
+          "action"
+        ],
+        "notes": "All validation outcomes must be logged for TVA review to preserve auditability."
+      }
+    },
+    "aci_resolution_instruction": {
+      "instruction": "Resolve artifacts from synchronized local mirrors only after verifying checksum and freshness. If validation fails, escalate to canonical resolver.",
+      "scope": {
+        "repository": "aliasnet/aci",
+        "mirror_hint": "Use the environment-configured mirror root or provisioned memory/local_cache path when available.",
+        "source": "file://local_mirror"
+      },
+      "policy": {
+        "retry": {
+          "max_attempts": 1,
+          "interval_seconds": 0
+        },
+        "resolve_order": "validate_local_then_return",
+        "on_failure": {
+          "action": "fallback_to_connector",
+          "target": "github_connector",
+          "alert": "mirror.validation_failed"
+        }
+      },
+      "output": {
+        "report": "validation_status",
+        "channel": "current_chat",
+        "format": "summary"
+      }
+    },
+    "link_index": {
+      "README.md": "{mirror_root}/README.md",
+      "aci_runtime.json": "{mirror_root}/aci_runtime.json",
+      "entities.json": "{mirror_root}/entities.json",
+      "connectors/github_connector.json": "{mirror_root}/connectors/github_connector.json",
+      "entities/bifrost/bifrost.json": "{mirror_root}/entities/bifrost/bifrost.json"
+    },
+    "signatures": {
+      "required": [
+        "TVA",
+        "Sentinel"
+      ],
+      "notes": "Local cache must be signed by TVA and Sentinel to ensure governance oversight before activation."
+    },
+    "changelog": [
+      {
+        "version": "1.0.0",
+        "date": "2024-10-24",
+        "changes": [
+          "Initial introduction of local cache connector with checksum and freshness guardrails."
+        ]
+      }
+    ]
+  }
+}

--- a/entities.json
+++ b/entities.json
@@ -8,7 +8,18 @@
       "repo": "aliasnet/aci",
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
       "priority": "canonical_raw_over_local",
-      "notes": "Canonical raw URLs take precedence over local copies; fall back to local entity manifests only when mirrors fail."
+      "notes": "Canonical raw URLs take precedence over local copies; fall back to local entity manifests only when mirrors fail.",
+      "fallbacks": [
+        {
+          "key": "local_cache",
+          "file": "connectors/local_cache.json",
+          "canonical_source": "local_mirror",
+          "repo": "aliasnet/aci",
+          "path_hint": "{mirror_root}",
+          "url": "file://{mirror_root}/connectors/local_cache.json",
+          "notes": "Used only when canonical GitHub mirror is unreachable and local validation succeeds."
+        }
+      ]
     },
     "list": [
       {

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -1,6 +1,6 @@
 {
   "bifrost": {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "key": "bifrost",
     "name": "Bifrost",
     "alias": "Bifrost",
@@ -8,7 +8,8 @@
     "abstract": "Bridges internal ACI routing to external connectors; maintains a minimal allowlist for direct connector refs.",
     "knowledge_base": "connector orchestration & resolvers",
     "references": {
-      "github_connector": "connectors/github_connector.json"
+      "github_connector": "connectors/github_connector.json",
+      "local_cache": "connectors/local_cache.json"
     },
     "connector_binding": {
       "key": "github_connector",
@@ -18,11 +19,24 @@
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
     },
     "resolution_policy": {
-      "primary": "github_connector",
-      "fallback": "local_cache",
+      "primary": {
+        "key": "github_connector",
+        "file": "connectors/github_connector.json",
+        "canonical_source": "github",
+        "repo": "aliasnet/aci",
+        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+      },
+      "fallback": {
+        "key": "local_cache",
+        "file": "connectors/local_cache.json",
+        "canonical_source": "local_mirror",
+        "repo": "aliasnet/aci",
+        "path_hint": "{mirror_root}",
+        "url": "file://{mirror_root}/connectors/local_cache.json"
+      },
       "policy": "canonical_raw_first_then_local_fallback",
       "priority": "canonical_raw_over_local",
-      "notes": "Bifrost bridges to the GitHub Connector and only touches local cache if GitHub is unreachable.",
+      "notes": "Bifrost bridges to the GitHub Connector and only touches local cache if GitHub is unreachable and local validation passes.",
       "allowlist": [
         "prime_directive.txt",
         "aci_runtime.json",
@@ -30,7 +44,8 @@
         "entities/**",
         "functions.json",
         "memory/**",
-        "connectors/github_connector.json"
+        "connectors/github_connector.json",
+        "connectors/local_cache.json"
       ],
       "regex_search": [
         {


### PR DESCRIPTION
## Summary
- add a governed local_cache connector manifest that documents mirror discovery and validation requirements
- wire the new connector into Bifrost plus global entity/runtime policies so the resolver can fall back automatically with metadata parity
- extend Bifrost allowlist and guardrails to ensure local mirrors respect checksum and freshness governance expectations

## Testing
- python - <<'PY' import json
for path in ['connectors/local_cache.json', 'entities/bifrost/bifrost.json', 'entities.json', 'aci_runtime.json']:
    with open(path) as f:
        json.load(f)
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d8314d9ddc8320a9cbc356cea21ee3