### PR TITLE
Expand GitHub connector coverage for governance docs

### DIFF
--- a/conflict_report.md
+++ b/conflict_report.md
@@ -1,0 +1,10 @@
+# Conflict Assessment
+
+- Compared current branch commit `910aee728f2164609964e3841218ad9c8a50c6bf` against upstream `aliasnet/aci` main snapshots via raw file download.
+- No structural merge conflicts detected: `connectors/github_connector.json` cleanly diverges by expanding regex coverage, notes, and link index entries.
+- Working tree reports a clean state with no unmerged paths.
+
+## Evidence
+
+- `git status -sb` shows a clean working tree.
+- Diff against the latest upstream manifest highlights only intentional additions to `connectors/github_connector.json` (regex expansion, notes updates, and new link index entries).

--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -17,7 +17,7 @@
       }
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; use local files only when mirrors are unavailable.",
+    "notes": "Canonical raw URLs take precedence over local copies; governance docs (root *.md, AGENTS.md, sanity.md) and connector manifests now resolve automatically via raw GitHub; escalate only for non-listed resources or protected data.",
     "signatures": {
       "required": [
         "ALIAS",
@@ -55,17 +55,20 @@
     },
     "regex_search": [
       {
-        "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt)$",
+        "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt|AGENTS\\.md|sanity\\.md|[^/]+\\.md|connectors/.+)$",
         "description": "Fallback resolution using regular expressions when file mappings are unknown."
       }
     ],
     "link_index": {
+      "AGENTS.md": "https://raw.githubusercontent.com/aliasnet/aci/main/AGENTS.md",
+      "ACI.md": "https://raw.githubusercontent.com/aliasnet/aci/main/ACI.md",
       "README.md": "https://raw.githubusercontent.com/aliasnet/aci/main/README.md",
       "aci_bootstrap.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
       "aci_commands.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_commands.json",
       "aci_mapping.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_mapping.json",
       "aci_runtime.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
       "alias.json": "https://raw.githubusercontent.com/aliasnet/aci/main/alias.json",
+      "connectors/github_connector.json": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
       "entities.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
       "entities/aci_repo/aci_repo.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/aci_repo/aci_repo.json",
       "entities/bifrost/bifrost.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
@@ -76,7 +79,8 @@
       "functions.json": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
       "memory/agi_memory/AGI/agi_agi_memory_operational_20250927-T105140Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/agi_memory/AGI/agi_agi_memory_operational_20250927-T105140Z.json",
       "memory/hivemind_memory/hivemind_memory_operational_20250919T161225Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/hivemind_memory_operational_20250919T161225Z.json",
-      "prime_directive.txt": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+      "prime_directive.txt": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+      "sanity.md": "https://raw.githubusercontent.com/aliasnet/aci/main/sanity.md"
     }
   }
 }

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -27,14 +27,18 @@
         "prime_directive.txt",
         "aci_runtime.json",
         "aci_bootstrap.json",
+        "AGENTS.md",
+        "sanity.md",
+        "*.md",
         "entities/**",
         "functions.json",
         "memory/**",
+        "connectors/**",
         "connectors/github_connector.json"
       ],
       "regex_search": [
         {
-          "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt)$",
+          "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt|AGENTS\\.md|sanity\\.md|[^/]+\\.md|connectors/.+)$",
           "description": "Fallback regex when mappings are unknown."
         }
       ]


### PR DESCRIPTION
## Summary
- extend Bifrost's allowlist and regex coverage so governance markdown and connector manifests can resolve without escalation
- widen the GitHub connector regex/link index and update its notes to cover AGENTS.md, sanity.md, root markdown, and connector paths
- note the auto-resolving categories directly in the connector metadata for future maintainers

## Testing
- python - <<'PY'
import json, re
with open('connectors/github_connector.json') as fh:
    cfg = json.load(fh)["github_connector"]
regexes = [re.compile(entry["pattern"]) for entry in cfg.get("regex_search", [])]
link_index = cfg.get("link_index", {})
source = cfg["aci_resolution_instruction"]["scope"]["source"]
for path in ["AGENTS.md", "sanity.md", "ACI.md", "README.md", "connectors/github_connector.json", "connectors/docs/example.md"]:
    url = link_index.get(path)
    if not url:
        for rx in regexes:
            if rx.match(path):
                url = source + path
                break
    print(path, url)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d8314f4a108320ad02e71a0879c0de