### PR TITLE
Fix Bifrost resolution policy connector keys

### DIFF
--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -19,20 +19,24 @@
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
     },
     "resolution_policy": {
-      "primary": {
-        "key": "github_connector",
-        "file": "connectors/github_connector.json",
-        "canonical_source": "github",
-        "repo": "aliasnet/aci",
-        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
-      },
-      "fallback": {
-        "key": "local_cache",
-        "file": "connectors/local_cache.json",
-        "canonical_source": "local_mirror",
-        "repo": "aliasnet/aci",
-        "path_hint": "{mirror_root}",
-        "url": "file://{mirror_root}/connectors/local_cache.json"
+      "primary": "github_connector",
+      "fallback": "local_cache",
+      "connector_metadata": {
+        "github_connector": {
+          "key": "github_connector",
+          "file": "connectors/github_connector.json",
+          "canonical_source": "github",
+          "repo": "aliasnet/aci",
+          "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+        },
+        "local_cache": {
+          "key": "local_cache",
+          "file": "connectors/local_cache.json",
+          "canonical_source": "local_mirror",
+          "repo": "aliasnet/aci",
+          "path_hint": "{mirror_root}",
+          "url": "file://{mirror_root}/connectors/local_cache.json"
+        }
       },
       "policy": "canonical_raw_first_then_local_fallback",
       "priority": "canonical_raw_over_local",


### PR DESCRIPTION
## Summary
- restore `resolution_policy.primary` and `resolution_policy.fallback` to connector key strings for compatibility
- retain the detailed connector descriptions under a new `connector_metadata` map so fallback documentation remains available

## Testing
- python - <<'PY'
import json
for path in ['connectors/local_cache.json', 'entities/bifrost/bifrost.json', 'entities.json', 'aci_runtime.json']:
    with open(path) as f:
        json.load(f)
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d83e2058248320b68c937cd3ea820f