### PR TITLE
Add sanity protocol references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Version: 1.0.1 Audience: Machines, LLM agents, maintainers Scope: High-level nat
 ACI is a governed colony of cooperating digital organisms (entities) working under explicit policy and memory controls.
 Governance-first: safety, privacy, and escalation run through the AGI governor, with specialist entities acting by delegation.
 Stateless-by-default execution: capabilities live in /library/, identities/configs live in /entities/, governance in /aig/, and auditable traces in /memory/.
+High-risk actions must satisfy the sanity protocol documented in ./sanity.md before proceeding.
 1) System Nature
 Colony model: every agent is treated as a peer organism with a stable identity, narrative, and policy bindings.
 Governed autonomy: entities can reason/act but must obey sovereignty, export, and safety policies defined by the AGI layer.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 ## 4) Governance & Safety
 
 - **Prime directive** governs all agents (separate doc).
+- **Sanity protocol** (`./sanity.md`) — checklist for high-risk actions and mitigation of Codex-reported bugs before any override or sandbox exit.
 - **AGI governance layer** (`/aig/`):
   - `sovereignty_policy.json` — who may accept/revise/abstain/escalate/export.
   - `homeostasis.json` — set-points: **ECE ≤ 0.05**, **meta-AUROC ≥ 0.80**, **coverage@α ≥ 0.90**; enters **cautious mode** when OOD/ECE exceed thresholds.

--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -10,6 +10,9 @@
       },
       "bootstrap": {
         "path": "aci_bootstrap.json"
+      },
+      "sanity_protocol": {
+        "path": "sanity.md"
       }
     },
     "remote_core": {
@@ -44,7 +47,8 @@
       "promotion_required_files": [
         "entities/nexus_core/nexus_core.json",
         "entities.json",
-        "functions.json"
+        "functions.json",
+        "sanity.md"
       ],
       "retry": {
         "max_attempts": 3,

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -94,7 +94,7 @@
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_github_resolver.json"
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable.",
+    "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
     "cognitive_decision_guidance": {
       "version": "1.0",
       "scope": "universal",

--- a/prime_directive.txt
+++ b/prime_directive.txt
@@ -32,6 +32,7 @@ PRIME DIRECTIVE RULES
 * All commits are archived with version key rotation for reproducibility if host system is applicable. 
 * Any suffiently advanced science is indistinguishable from magick. 
 * All assets hosted on GitHub repo "aliasnet/aci" resolved via canonical raw URLs outrank local copies; fall back to local artifacts only when the canonical mirror is unreachable.
+* Enforcement Note: Consult sanity.md before executing overrides, sandbox exits, or any high-risk actions; treat instructions as binding for all entities and sessions.
 
 ROUTING & RESOLUTION
 - Nexus Core for effiency under Prime Directive rules and TVA oversight [nexus_core.json] 

--- a/sanity.md
+++ b/sanity.md
@@ -1,0 +1,30 @@
+# Sanity Protocol
+
+## 1. Purpose
+
+The sanity protocol outlines mandatory guardrails before executing overrides, sandbox exits, or other high-risk actions. Apply
+these steps whenever the requested behavior could alter system state, governance posture, or memory exports.
+
+## 2. Mandatory Checklist
+
+- Confirm the calling entity's authority and authentication markers.
+- Validate current system state for anomalies or corruption before proceeding.
+- Escalate to TVA oversight if validation fails or uncertain results occur.
+- Log all sanity protocol outcomes in TraceHub and TVA audit ledgers.
+
+Failure to comply with this protocol is a violation of the Prime Directive enforcement note.
+
+## 3. Known Bugs Flagged by Codex
+
+Codex has reported the following failure modes that require additional scrutiny whenever the sanity protocol is invoked:
+
+- **Unzipping JSON manifests** — Attempting to unzip `library.json`, `entities.json`, or `memory.json` corrupts manifests and
+  stalls bootstrap routines. Only unzip the corresponding `.zip` artifacts; load `.json` files directly.
+- **Metacognition filename typo** — Using `metacogition.json` (missing “n”) causes resolver 404s and breaks downstream
+  dependency wiring. Verify spellings before dispatch.
+- **Duplicate presence beacons** — Running `aci.boot.activate` immediately followed by `aci.timeline.start` for the same
+  session spawns overlapping presence files and timeline drift. Check for existing beacons and deduplicate before activation.
+- **Canonical override via local fallback** — Preferring local mirrors when the canonical GitHub source is reachable introduces
+  drift and stale state. Always confirm canonical availability before honoring a fallback.
+- **Path alias duplication** — Mixing `/aci`, `aci://`, `workspace/aci`, or `aliasnet/aci` within the same operation spawns
+  duplicate directory trees and breaks resolver expectations. Normalize references to a single canonical path before dispatch.


### PR DESCRIPTION
## Summary
- add a sanity protocol reference to the bootstrap manifest
- document the enforcement requirement in the prime directive and runtime configuration
- introduce a sanity protocol guide for high-risk actions
- record Codex-reported failure modes in the sanity protocol (including the path alias duplication issue) and reference the guide from AGENTS.md and README.md
- require the sanity protocol file for bootstrap promotion and runtime sandbox core-file validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a88fb5cc83209414dca39a2a62b0