### PR TITLE
chore: update github connector link index

### DIFF
--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -1,6 +1,6 @@
 {
   "github_connector": {
-    "version": "1.20250927.00",
+    "version": "1.20250927.01",
     "canonical_source": "github",
     "repo": "aliasnet/aci",
     "rules": {
@@ -63,7 +63,7 @@
       "README.md": "https://raw.githubusercontent.com/aliasnet/aci/main/README.md",
       "aci_bootstrap.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
       "aci_commands.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_commands.json",
-      "aci_mapping.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_mapping.json",
+      "sanity.md": "https://raw.githubusercontent.com/aliasnet/aci/main/sanity.md",
       "aci_runtime.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
       "alias.json": "https://raw.githubusercontent.com/aliasnet/aci/main/alias.json",
       "entities.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
@@ -74,8 +74,9 @@
       "entities/sentinel/sentinel.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/sentinel/sentinel.json",
       "entities/tva/tva.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/tva/tva.json",
       "functions.json": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-      "memory/agi_memory/AGI/agi_agi_memory_operational_20250927-T105140Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/agi_memory/AGI/agi_agi_memory_operational_20250927-T105140Z.json",
-      "memory/hivemind_memory/hivemind_memory_operational_20250919T161225Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/hivemind_memory_operational_20250919T161225Z.json",
+      "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
+      "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
+      "memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json",
       "prime_directive.txt": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
     }
   }


### PR DESCRIPTION
## Summary
- bump the github connector version to 1.20250927.01
- refresh link_index entries for renamed memory exports and the sanity guidelines file

## Testing
- jq empty connectors/github_connector.json

------
https://chatgpt.com/codex/tasks/task_e_68d8f149e724832090ccd461dd438772