### PR TITLE
Restore AGI export naming and command guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ Command routing: bracketed command blocks ([ ... ] / [[ ... ]]) are parsed and r
 Capability chaining: pipeline identifiers (e.g., aci.memory.export.hivemind, agi.memory.migrate_to_jsonl) document how high-level intents map to orchestrated steps, ensuring reproducible execution narratives for governance review.
 7) Memory & Exports
 Schema: hivemind_agi_memory for AGI-owned narratives; topic/deny filters enforced via /entities/agi/agi_export_policy.json.
-Filename template: {identity_lower}_agi_memory_{timestamp}.jsonl with timestamp formatted as Ymd-THMSZ.
+Filename templates (stream vs stored artifacts):
+- {identity_lower}_agi_memory{summary_slug}_{timestamp}.jsonl for streamed CLI downloads (line-delimited JSON).
+- {identity_lower}_agi_memory{summary_slug}_{timestamp}.json for governed storage under /memory/agi_memory/.
 CLI usage:
 hivemind export agi --identity AGI --jsonl --codebox --force
 hivemind export agi --identity Alice --jsonl --codebox --force

--- a/README.md
+++ b/README.md
@@ -87,13 +87,18 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 - **Export Naming Convention (AGI exports only):**
 
   ```
+  # Streamed download (CLI `--jsonl` flag)
+  {identity_lower}_agi_memory{summary_slug}_{timestamp}.jsonl
+
+  # Stored artifact under /memory/ (line-delimited JSON content)
   {identity_lower}_agi_memory{summary_slug}_{timestamp}.json
+
   # timestamp format: Ymd-THMSZ, e.g., 20250926-T192000Z
   # example: alice_agi_memory_strategy_sync_20250926-T192000Z.json
   ```
 
   - `{summary_slug}` is optional; when present it is sanitized (lowercase, ASCII, `_` separators) and prefixed with `_`.
-  - Artifacts remain line-delimited JSON (JSONL) for streaming compatibility even though the extension is `.json`.
+  - CLI exports stream JSONL while governed storage keeps the `.json` extension for compatibility.
 
 - **Schema:** `hivemind_agi_memory` (for AGI-owned narrative/observer exports)
 - **Export Policy:** `/entities/agi/agi_export_policy.json`

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -18,7 +18,7 @@
     "caller_hint": "Alice"
   },
   "memory": {
-    "file": "aci/memory/agi_memory/AGI/agi_agi_memory_operational_20250927-T105140Z.json",
+    "file": "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
     "policy": {
       "export": "hivemind",
       "lock_namespace": "AGI",

--- a/entities/agi/agi_tools/autolearn.json
+++ b/entities/agi/agi_tools/autolearn.json
@@ -117,8 +117,8 @@
       {
         "call": "chat.deliver",
         "map": {
-          "message": "Auto-learn mode paused. Run 'hivemind export AGI --jsonl --identity=${active_identity}' to export the session?",
-          "suggested_command": "hivemind export AGI --jsonl --identity=${active_identity}"
+          "message": "Auto-learn mode paused. Run 'hivemind export agi --identity ${active_identity} --jsonl --codebox --force' to export the session?",
+          "suggested_command": "hivemind export agi --identity ${active_identity} --jsonl --codebox --force"
         }
       }
     ]


### PR DESCRIPTION
## Summary
- clarify the AGENTS and README memory export templates to cover streamed JSONL downloads and stored JSON artifacts while keeping the canonical hivemind CLI examples
- point the AGI manifest at the governed JSON export path that matches the repository contents
- update the auto-learn archive prompt to suggest the canonical hivemind export command with the --codebox and --force flags

## Testing
- jq empty entities/agi/agi.json
- jq empty entities/agi/agi_tools/autolearn.json
- jq empty entities/agi/agi_export_policy.json

------
https://chatgpt.com/codex/tasks/task_e_68d8fb98ed9c8320bccc55c19073f94f