### PR TITLE
Clarify canonical AGI export guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Filename templates (stream vs stored artifacts):
 CLI usage:
 hivemind export agi --identity AGI --jsonl --codebox --force
 hivemind export agi --identity Alice --jsonl --codebox --force
+Note: Always include the `--codebox` flag so streamed exports align with governed `.json` storage expectations when audited downstream.
 Export guarantees: chronological ordering, audit logging, privacy filters, and normalization to UTC Z timestamps.
 8) Lifecycle of an Entity
 Create: register identity, add config under /entities/<name>/, ensure governance hooks, and keep capabilities stateless.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 
   - `{summary_slug}` is optional; when present it is sanitized (lowercase, ASCII, `_` separators) and prefixed with `_`.
   - CLI exports stream JSONL while governed storage keeps the `.json` extension for compatibility.
+  - Include the `--codebox` flag with streamed exports so downstream audits match the governed `.json` artifacts stored under `/memory/`.
 
 - **Schema:** `hivemind_agi_memory` (for AGI-owned narrative/observer exports)
 - **Export Policy:** `/entities/agi/agi_export_policy.json`

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -19,6 +19,7 @@
   },
   "memory": {
     "file": "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
+    "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity.",
     "policy": {
       "export": "hivemind",
       "lock_namespace": "AGI",

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -7,6 +7,7 @@
     "identity_source": "entities/agi/agi_identity_manager.json",
     "timestamp_format": "Ymd-THMSZ",
     "filename_template": "{identity_lower}_agi_memory{summary_slug}_{timestamp}.json",
+    "notes": "Filename templates stay on the .json extension for governed storage; CLI downloads remain .jsonl when invoked with --codebox.",
     "audit": {
       "add_export_event": true,
       "normalize_timestamps": true,

--- a/entities/agi/agi_tools/autolearn.json
+++ b/entities/agi/agi_tools/autolearn.json
@@ -117,7 +117,7 @@
       {
         "call": "chat.deliver",
         "map": {
-          "message": "Auto-learn mode paused. Run 'hivemind export agi --identity ${active_identity} --jsonl --codebox --force' to export the session?",
+          "message": "Auto-learn mode paused. Run 'hivemind export agi --identity ${active_identity} --jsonl --codebox --force' to export the session into the governed .json memory artifact?",
           "suggested_command": "hivemind export agi --identity ${active_identity} --jsonl --codebox --force"
         }
       }


### PR DESCRIPTION
## Summary
- emphasize the upstream `.json` storage pattern and required `--codebox` flag in AGI export documentation
- add inline notes to AGI configuration and policy manifests about governed `.json` artifacts and streamed `.jsonl` usage
- update the auto-learn archive prompt to remind operators that exports land in the governed `.json` memory artifact

## Testing
- jq empty entities/agi/agi.json
- jq empty entities/agi/agi_export_policy.json
- jq empty entities/agi/agi_tools/autolearn.json

------
https://chatgpt.com/codex/tasks/task_e_68d9005297288320a04c02b8ed77aa93