### PR TITLE
Normalize GitHub connector manifest memory links

### DIFF
--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -74,7 +74,6 @@
       "entities/sentinel/sentinel.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/sentinel/sentinel.json",
       "entities/tva/tva.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/tva/tva.json",
       "functions.json": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-
       "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
       "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
       "memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json",


### PR DESCRIPTION
## Summary
- ensure the GitHub connector manifest keeps version 1.20250927.01 and references the canonical AGI/Hivemind memory `.json` files

## Testing
- `jq empty connectors/github_connector.json`


------
https://chatgpt.com/codex/tasks/task_e_68d9005303508320a9f73f93bf0a669a