### PR TITLE
Expand governance doc coverage for GitHub connector

### DIFF
--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -1,6 +1,6 @@
 {
   "github_connector": {
-    "version": "1.20250927.00",
+    "version": "1.20250927.01",
     "canonical_source": "github",
     "repo": "aliasnet/aci",
     "rules": {
@@ -17,7 +17,7 @@
       }
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; use local files only when mirrors are unavailable.",
+    "notes": "Canonical raw URLs take precedence over local copies; governance Markdown (AGENTS.md, sanity.md, other root *.md) and the connectors/ directory now resolve automatically, while off-pattern requests still require human approval.",
     "signatures": {
       "required": [
         "ALIAS",
@@ -57,10 +57,21 @@
       {
         "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt)$",
         "description": "Fallback resolution using regular expressions when file mappings are unknown."
+      },
+      {
+        "pattern": "^(AGENTS\\.md|sanity\\.md|[^/]+\\.md)$",
+        "description": "Governance Markdown files in the repository root."
+      },
+      {
+        "pattern": "^connectors/.+$",
+        "description": "Connector manifests and documentation."
       }
     ],
     "link_index": {
       "README.md": "https://raw.githubusercontent.com/aliasnet/aci/main/README.md",
+      "AGENTS.md": "https://raw.githubusercontent.com/aliasnet/aci/main/AGENTS.md",
+      "ACI.md": "https://raw.githubusercontent.com/aliasnet/aci/main/ACI.md",
+      "sanity.md": "https://raw.githubusercontent.com/aliasnet/aci/main/sanity.md",
       "aci_bootstrap.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
       "aci_commands.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_commands.json",
       "aci_mapping.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_mapping.json",

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -1,6 +1,6 @@
 {
   "bifrost": {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "key": "bifrost",
     "name": "Bifrost",
     "alias": "Bifrost",
@@ -30,12 +30,23 @@
         "entities/**",
         "functions.json",
         "memory/**",
-        "connectors/github_connector.json"
+        "connectors/**",
+        "AGENTS.md",
+        "sanity.md",
+        "*.md"
       ],
       "regex_search": [
         {
           "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt)$",
           "description": "Fallback regex when mappings are unknown."
+        },
+        {
+          "pattern": "^(AGENTS\\.md|sanity\\.md|[^/]+\\.md)$",
+          "description": "Governance Markdown files in the repository root."
+        },
+        {
+          "pattern": "^connectors/.+$",
+          "description": "Connector manifests and documentation."
         }
       ]
     }


### PR DESCRIPTION
## Summary
- widen Bifrost's allowlist and regex coverage so governance Markdown and connector paths no longer require escalation
- expand the GitHub connector's regex search and link index, documenting the automatic coverage of root Markdown and connectors assets

## Testing
- curl -I https://raw.githubusercontent.com/aliasnet/aci/main/AGENTS.md
- curl -I https://raw.githubusercontent.com/aliasnet/aci/main/sanity.md
- curl -I https://raw.githubusercontent.com/aliasnet/aci/main/ACI.md
- curl -I https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json


------
https://chatgpt.com/codex/tasks/task_e_68d83bfd30588320a51fbdb66935b21a