### PR TITLE
Update memory export naming guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ hivemind export agi --identity Alice --jsonl --code --force
   - `allow_topics`: `session_start`, `session_end`, `intent`, `narrative`, `analysis`, `artifact`, `validation`, `decision`, `policy`, `policy_update`, `diff`, `patch`, `export`, `obstacle`, `next_steps`, `commit`.
   - `deny_tags`: `secret`, `credential`, `token`, `api_key`, `password`, `runtime_secret`, `private_key`, `raw_text`, `internal_path`, `pii`.
   - `drop_if_topic_missing: true` and `default_topic: "narrative"`.
-- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `hivemind_memory_yyyymmdd-ThhmmssZ.json`.
+- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` (e.g., `agi-agi-memory-ab12cd-20250926-T192000Z.json`). When no identity is detected, HiveMind falls back to `hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`. AGI-owned exports typically appear as `agi-agi-memory-…`, `alice-agi-memory-…`, or `external-agi-memory-…` variants.
 - Export prompts enter thinking mode, stay bound to the paused HiveMind session, and when `--code` is active they print the inline block before asking if a download link is still required.
 
 **Identity binding:**


### PR DESCRIPTION
## Summary
- update the README export naming guidance to describe the hyphenated pattern with short checksum suffix
- document the HiveMind fallback filename when no identity is detected
- outline common AGI export filename variants for clarity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83c26082883209fc06463ebbffc1c