### PR TITLE
Update HiveMind export filename templates

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -18,7 +18,7 @@
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "--jsonl (line-delimited JSON persisted as .json), --download (persist to file), --code (render in chat code fence), --slice:<type> (session_only/full/range:<ts>/entity:<name>), --force (pause + export even if safeguards protest)",
         "description": "Exports the current HiveMind session snapshot with TVA + Sentinel oversight",
-        "output_default": "hivemind_memory_yyyymmdd-ThhmmssZ.json"
+        "output_default": "{identity|-fallback}-hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
       },
       {
         "command": "hivemind export agi",
@@ -26,7 +26,7 @@
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
-        "output_default": "agi_memory/<identity>/<identity>_agi_memory_yyyymmdd-ThhmmssZ.json"
+        "output_default": "{identity|-fallback}-agi-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- update the default HiveMind session export filename template to the new hyphenated pattern with identity and shortsum tokens
- align the AGI export default filename template with the updated identity-aware hyphenated naming convention

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83c2a0e0083209003fc422954ad6f