### PR TITLE
Handle legacy actor alias in migrator

### DIFF
--- a/entities/agi/agi_tools/migrate_to_jsonl/archive/migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/archive/migrate.py
@@ -52,6 +52,7 @@ REQUIRED_KEYS = ("timestamp", "role", "identity", "content", "metadata")
 LEGACY_IDENTITY_KEYS = (
     "entity",
     "actor",
+    "agent",
     "speaker",
     "author",
     "by",
@@ -526,7 +527,7 @@ def validate_line(entry: Dict[str, Any]) -> None:
                     metadata = existing_metadata
                 else:
                     metadata = {"legacy_metadata": existing_metadata}
-                metadata.setdefault("legacy_identity_key", legacy_key)
+                metadata["legacy_identity_key"] = legacy_key
                 entry["metadata"] = metadata
                 break
 

--- a/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
@@ -185,6 +185,22 @@ class ArchivedMigratorPathResolutionTests(unittest.TestCase):
         )
         self.assertEqual(filename, "agi_agi_memory_20241231T235959Z.json")
 
+    def test_validate_line_promotes_actor_identity(self) -> None:
+        module = self.module
+        entry = {
+            "timestamp": "2024-01-01T00:00:00Z",
+            "role": "observer",
+            "actor": "Legacy Actor",
+            "content": "hello world",
+            "metadata": {},
+        }
+
+        module.validate_line(entry)
+
+        self.assertEqual(entry["identity"], "Legacy Actor")
+        self.assertNotIn("actor", entry)
+        self.assertEqual(entry["metadata"].get("legacy_identity_key"), "actor")
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- allow the archived migrator to promote legacy `actor` and `agent` identity aliases to the canonical `identity` field
- ensure migrated records annotate the original identity key in metadata when a legacy alias is used
- extend the archived migrator regression tests to cover actor-only inputs

## Testing
- python -m unittest entities.agi.agi_tools.migrate_to_jsonl.test_migrate

------
https://chatgpt.com/codex/tasks/task_e_68d90474469483209b538181fa651bb6