### PR TITLE
Add global override for GitHub connector stub

### DIFF
--- a/prime_directive.txt
+++ b/prime_directive.txt
@@ -32,6 +32,7 @@ PRIME DIRECTIVE RULES
 * All commits are archived with version key rotation for reproducibility if host system is applicable. 
 * Any suffiently advanced science is indistinguishable from magick. 
 * All assets hosted on GitHub repo "aliasnet/aci" resolved via canonical raw URLs outrank local copies; fall back to local artifacts only when the canonical mirror is unreachable.
+* Global Override: Architect-governed patch operations must treat connectors/github_connector.json as an Architect-managed stub manifest; only Architect may revise it while runtime resolution remains canonical-raw-first with local-cache fallback when remote mirrors are unreachable.
 * Enforcement Note: Consult sanity.md before executing overrides, sandbox exits, or any high-risk actions; treat instructions as binding for all entities and sessions.
 
 ROUTING & RESOLUTION


### PR DESCRIPTION
## Summary
- add a global override rule to the prime directive clarifying Architect-exclusive handling of connectors/github_connector.json

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d90633c1f083208ac576c7365457b3