### PR TITLE
Add Sentinel audit router and pipelines

### DIFF
--- a/entities/sentinel/sentinel.json
+++ b/entities/sentinel/sentinel.json
@@ -1,13 +1,27 @@
 {
-  "version": "BASELINE-2025-09-21",
+  "version": "2025-09-27.1",
   "entity": "Sentinel",
   "role": "guardian",
-  "status": "placeholder",
-  "description": "Sentinel Protocol placeholder manifest. Define privacy, security, and resilience guardianship policies here.",
-  "todo": [
-    "Implement risk scoring and mitigation pipelines for functions 6232-6263.",
-    "Document signature requirements and incident response procedures.",
-    "Integrate with TVA anomaly reporting and Nexus Core telemetry feeds."
+  "status": "operational",
+  "description": "Governed guardian responsible for audit routing, signature enforcement, and user safety posture inside the ACI runtime.",
+  "audit": {
+    "router_config": "library/audit/audit_router.json",
+    "default_mode": "session_only",
+    "export_instruction": "Provide \"export_file\": true when invoking pipelines.sentinel.audit to generate a persistent export alongside the session log."
+  },
+  "guidance": [
+    "Session-only logging keeps activity confined to /memory/audit/ for the active runtime window.",
+    "Persistent exports require the export sink to be enabled and will emit governed JSONL files under /memory/audit/exports/.",
+    "Signature enforcement follows the router controls; when export_file mode is active, presence records must include a valid Sentinel/ALIAS signature."
   ],
-  "notes": "Created to satisfy entity index references until the full Sentinel manifest is authored."
+  "changelog": [
+    {
+      "version": "2025-09-27.1",
+      "notes": [
+        "Promoted Sentinel from placeholder to operational guardian.",
+        "Linked the audit router configuration and documented export vs session-only behavior.",
+        "Clarified signature enforcement expectations tied to export-enabled runs."
+      ]
+    }
+  ]
 }

--- a/functions.json
+++ b/functions.json
@@ -9,6 +9,56 @@
     "notes": "Canonical raw URLs take precedence over local copies; local function catalogs are fallback only when mirrors fail."
   },
   "pipelines": {
+    "sentinel.audit": {
+      "description": "Route Sentinel audit events according to the audit router configuration.",
+      "steps": [
+        {
+          "call": "audit.router.load",
+          "map": {
+            "file": "library/audit/audit_router.json"
+          }
+        },
+        {
+          "call": "audit.event.compose",
+          "map": {
+            "router": "$steps.0.router",
+            "action": "$params.action",
+            "session_id": "$params.session_id",
+            "actor": "$params.actor",
+            "payload": "$params.payload",
+            "signature": "$params.signature",
+            "export_override": "$params.export_file",
+            "timestamp": "$now"
+          }
+        },
+        {
+          "call": "audit.router.dispatch",
+          "map": {
+            "router": "$steps.0.router",
+            "event": "$steps.1.event"
+          }
+        }
+      ]
+    },
+    "sentinel.verify_signatures": {
+      "description": "Validate presence file signatures when the router requires it.",
+      "steps": [
+        {
+          "call": "audit.router.load",
+          "map": {
+            "file": "library/audit/audit_router.json"
+          }
+        },
+        {
+          "call": "audit.signatures.check",
+          "map": {
+            "router": "$steps.0.router",
+            "files": "$params.files",
+            "key_id": "$params.key_id"
+          }
+        }
+      ]
+    },
     "aci.boot.activate": {
       "description": "Activation sequence: declare session ID, start presence beacon, anchor TVA, adopt legacy memory files. Never delete.",
       "steps": [

--- a/library/audit/audit_router.json
+++ b/library/audit/audit_router.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0.0",
+  "router": {
+    "name": "sentinel.audit_router",
+    "description": "Routes Sentinel audit events either to session-only memory or to governed export files based on runtime toggles.",
+    "default_sink": "session_only",
+    "sinks": {
+      "session_only": {
+        "enabled": true,
+        "mode": "in_session",
+        "path_template": "/memory/audit/session_${session_id}.jsonl",
+        "rotation": "per_session",
+        "notes": "Keeps audit events inside the current runtime session under /memory/audit/."
+      },
+      "export_file": {
+        "enabled": false,
+        "mode": "export",
+        "path_template": "/memory/audit/exports/audit_${session_id}_${timestamp}.jsonl",
+        "requires_signature": true,
+        "notes": "When enabled, emit immutable exports suitable for transfer or archival."
+      }
+    },
+    "controls": {
+      "allow_unsigned_events": true,
+      "enforce_signatures_when_enabled": true,
+      "metadata_keys": [
+        "action",
+        "session_id",
+        "actor",
+        "signature"
+      ],
+      "export_opt_in_flag": "export_file"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Sentinel audit router configuration with session and export sinks
- wire pipelines.sentinel.audit and pipelines.sentinel.verify_signatures to the router for routing and signature enforcement
- promote the Sentinel entity to operational status and document how to request persistent exports

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9051bd760832097fcc6e97ac17799