### PR TITLE
Update HiveMind export filename templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Command routing: bracketed command blocks ([ ... ] / [[ ... ]]) are parsed and r
 Capability chaining: pipeline identifiers (e.g., aci.memory.export.hivemind, agi.memory.migrate_to_jsonl) document how high-level intents map to orchestrated steps, ensuring reproducible execution narratives for governance review.
 7) Memory & Exports
 Schema: hivemind_agi_memory for AGI-owned narratives; topic/deny filters enforced via /entities/agi/agi_export_policy.json.
-Filename template: {identity_lower}_agi_memory_{timestamp}.jsonl with timestamp formatted as Ymd-THMSZ.
+Filename template: {identity_lower}-agi-memory-{shortsum}-{timestamp}.jsonl with timestamp formatted as Ymd-THMSZ.
 CLI usage:
 hivemind export agi --identity AGI --jsonl --codebox --force
 hivemind export agi --identity Alice --jsonl --codebox --force

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 /memory/
   agi_memory/
     AGI/
-      agi_agi_memory_<timestamp>.json
+      agi-agi-memory-<shortsum>-<timestamp>.jsonl
     Alice/
-      alice_agi_memory_<timestamp>.json
+      alice-agi-memory-<shortsum>-<timestamp>.jsonl
     External/
-      external_agi_memory_<timestamp>.json
+      external-agi-memory-<shortsum>-<timestamp>.jsonl
 ```
 
 ---
@@ -87,9 +87,9 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 - **Export Naming Convention (AGI exports only):**
 
   ```
-  {identity_lower}_agi_memory_{timestamp}.json
+  {identity_lower}-agi-memory-{shortsum}-{timestamp}.jsonl
   # timestamp format: Ymd-THMSZ, e.g., 20250926-T192000Z
-  # example: alice_agi_memory_20250926-T192000Z.json
+  # example: alice-agi-memory-1a2b3c-20250926-T192000Z.jsonl
   ```
 
 - **Schema:** `hivemind_agi_memory` (for AGI-owned narrative/observer exports)

--- a/entities/agi/README_ENTITY.txt
+++ b/entities/agi/README_ENTITY.txt
@@ -10,7 +10,7 @@ PURPOSE: Deterministic operating contract for AGI + AGI Proxy under ACI governan
 
 1) REQUIRED PATHS
 - AGI spec:                    aci/entities/agi/agi.json
-- AGI memory (locked):         aci/memory/agi_memory/AGI/agi_agi_memory_yyyymmdd-ThhmmssZ.jsonl
+- AGI memory (locked):         aci/memory/agi_memory/AGI/agi-agi-memory-<shortsum>-<timestamp>.jsonl
 - AGI Proxy spec:              aci/entities/agi_proxy/agi_proxy.json
 - EEC base:                    aci/entities/agi_proxy/eec/eec_base.json
 - EEC presets:                 aci/entities/agi_proxy/eec/*.json
@@ -37,7 +37,7 @@ RESPONSE:
 
 6) PROMOTION FLOW
 - Promotion request must include: tva_anchor_id, sentinel_audit_id, Human.approval=true.
-- On success: copy artifact to persist://, append entry to aci/memory/agi_memory/AGI/agi_agi_memory_yyyymmdd-ThhmmssZ.jsonl, emit TVA post-anchor + finalize Sentinel audit.
+- On success: copy artifact to persist://, append entry to aci/memory/agi_memory/AGI/agi-agi-memory-<shortsum>-<timestamp>.jsonl, emit TVA post-anchor + finalize Sentinel audit.
 
 7) MEMORY POLICY
 - Namespace = AGI; governed mutable index with audit trail; canonical raw mirrors outrank local snapshots while the namespace lock remains in place.

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -6,7 +6,7 @@
     "path_template": "/memory/agi_memory/{identity}/{filename}",
     "identity_source": "entities/agi/agi_identity_manager.json",
     "timestamp_format": "Ymd-THMSZ",
-    "filename_template": "{identity_lower}_agi_memory_{timestamp}.jsonl",
+    "filename_template": "{identity_lower}-agi-memory-{shortsum}-{timestamp}.jsonl",
     "audit": {
       "add_export_event": true,
       "normalize_timestamps": true,

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -16,9 +16,9 @@
     "note": "Enter thinking mode, stay within the active HiveMind session context, and if inline code is emitted ask whether a download link is still needed."
   },
   "output": {
-    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
+    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY}-agi-memory-${SHORTSUM}-${DATE}-T${TIME}Z.${FORMAT}",
     "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY}/adapters/",
-    "manifest_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY}_agi_memory_${DATE}-T${TIME}Z.json"
+    "manifest_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY}-agi-memory-${SHORTSUM}-${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -14,7 +14,7 @@
     "note": "Enter thinking mode, stay within the active HiveMind session context, and if inline code is emitted ask whether a download link is still needed."
   },
   "output": {
-    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY}_agi_memory_${DATE}-T${TIME}Z.json"
+    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY}-agi-memory-${SHORTSUM}-${DATE}-T${TIME}Z.jsonl"
   },
   "sandbox_overrides": {
     "internet": false

--- a/entities/agi/agi_tools/migrate_to_jsonl/archive/migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/archive/migrate.py
@@ -171,7 +171,8 @@ def load_policy(policy_path: Path = POLICY_FILE) -> Dict[str, Any]:
         raise MigrationError("agi_export_policy.json must define agi_memory block")
 
     filename_template = memory.get(
-        "filename_template", "{identity_lower}_agi_memory_{timestamp}.jsonl"
+        "filename_template",
+        "{identity_lower}-agi-memory-{shortsum}-{timestamp}.jsonl",
     )
     timestamp_format_hint = memory.get("timestamp_format", "Ymd-THMSZ")
 

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -14,19 +14,19 @@
     "commands": [
       {
         "command": "hivemind export session",
-        "command_rules": "If no parameter is provided, default to --download --jsonl --code --force while pausing the active session. JSONL payloads are persisted with a .json extension, and --code prompts the model to ask whether a download link is still required after the code fence.",
+        "command_rules": "If no parameter is provided, default to --download --jsonl --code --force while pausing the active session. JSONL payloads are persisted with a .jsonl extension, and --code prompts the model to ask whether a download link is still required after the code fence.",
         "default_parameter": "--download --jsonl --code --force",
-        "parameters": "--jsonl (line-delimited JSON persisted as .json), --download (persist to file), --code (render in chat code fence), --slice:<type> (session_only/full/range:<ts>/entity:<name>), --force (pause + export even if safeguards protest)",
+        "parameters": "--jsonl (line-delimited JSON persisted as .jsonl), --download (persist to file), --code (render in chat code fence), --slice:<type> (session_only/full/range:<ts>/entity:<name>), --force (pause + export even if safeguards protest)",
         "description": "Exports the current HiveMind session snapshot with TVA + Sentinel oversight",
-        "output_default": "{identity|-fallback}-hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
+        "output_default": "{identity|-fallback}-hivemind-memory-{shortsum}-{timestamp}.jsonl"
       },
       {
         "command": "hivemind export agi",
-        "command_rules": "Requires the session to remain paused until AGI export completes. Defaults mirror --download --jsonl --code --force; JSONL payloads still use a .json extension, and --code prompts the model to confirm whether a download link is needed after the inline block.",
+        "command_rules": "Requires the session to remain paused until AGI export completes. Defaults mirror --download --jsonl --code --force; JSONL payloads still use a .jsonl extension, and --code prompts the model to confirm whether a download link is needed after the inline block.",
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
-        "output_default": "{identity|-fallback}-agi-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
+        "output_default": "{identity|-fallback}-agi-memory-{shortsum}-{timestamp}.jsonl"
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- update the default HiveMind session export filename template to the new hyphenated pattern with identity and shortsum tokens
- align the AGI export default filename template with the updated identity-aware hyphenated naming convention
- refresh documentation and EEC export templates to describe the hyphenated filename pattern

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d906f0d93883208d92b1b0579d0b6e