### PR TITLE
Add readiness validation report for connector updates

### DIFF
--- a/readiness_report.md
+++ b/readiness_report.md
@@ -1,0 +1,17 @@
+# Readiness Validation Summary
+
+## Context
+The GitHub connector and Bifrost routing updates introduce new configuration manifests that must stay JSON-valid and aligned with the shared mirror policy across runtime and bootstrap paths. This checklist records the validation commands executed to confirm the branch is ready for merge.
+
+## Validation Checklist
+- [x] `python -m json.tool connectors/github_connector.json`
+- [x] `python -m json.tool entities/bifrost/bifrost.json`
+- [x] `python -m json.tool aci_bootstrap.json`
+- [x] `python -m json.tool aci_runtime.json`
+- [x] `python -m json.tool alias.json`
+- [x] `python -m json.tool entities.json`
+- [x] `python -m json.tool entities/aci_repo/aci_repo.json`
+- [x] `python -m json.tool functions.json`
+
+## Result
+All listed manifests parsed successfully, confirming the configuration set is ready for final review and integration.


### PR DESCRIPTION
## Summary
- add a readiness report documenting the json validation checklist for the github connector and bifrost routing manifests

## Testing
- python -m json.tool connectors/github_connector.json
- python -m json.tool entities/bifrost/bifrost.json
- python -m json.tool aci_bootstrap.json
- python -m json.tool aci_runtime.json
- python -m json.tool alias.json
- python -m json.tool entities.json
- python -m json.tool entities/aci_repo/aci_repo.json
- python -m json.tool functions.json

------
https://chatgpt.com/codex/tasks/task_e_68d7d81fa59c8320b38445b12dbb5888