### PR TITLE
Clarify memory export naming patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ hivemind export agi --identity Alice --jsonl --code --force
   - `allow_topics`: `session_start`, `session_end`, `intent`, `narrative`, `analysis`, `artifact`, `validation`, `decision`, `policy`, `policy_update`, `diff`, `patch`, `export`, `obstacle`, `next_steps`, `commit`.
   - `deny_tags`: `secret`, `credential`, `token`, `api_key`, `password`, `runtime_secret`, `private_key`, `raw_text`, `internal_path`, `pii`.
   - `drop_if_topic_missing: true` and `default_topic: "narrative"`.
-- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` (e.g., `agi-agi-memory-ab12cd-20250926-T192000Z.json`).
+- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` (e.g., `agi-agi-memory-ab12cd-20250926-T192000Z.json`). The hyphenated prefix explicitly binds the export to both the entity identity and the owning module for auditability.
 - When no identity is detected, HiveMind falls back to `hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` to ensure the export is still traceable.
 - AGI variants follow this convention, producing names such as `agi-agi-memory-<shortsum>-yyyymmdd-ThhmmssZ.json`, `alice-agi-memory-<shortsum>-yyyymmdd-ThhmmssZ.json`, or `external-agi-memory-<shortsum>-yyyymmdd-ThhmmssZ.json`.
 - Export prompts enter thinking mode, stay bound to the paused HiveMind session, and when `--code` is active they print the inline block before asking if a download link is still required.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ hivemind export agi --identity Alice --jsonl --code --force
   - `allow_topics`: `session_start`, `session_end`, `intent`, `narrative`, `analysis`, `artifact`, `validation`, `decision`, `policy`, `policy_update`, `diff`, `patch`, `export`, `obstacle`, `next_steps`, `commit`.
   - `deny_tags`: `secret`, `credential`, `token`, `api_key`, `password`, `runtime_secret`, `private_key`, `raw_text`, `internal_path`, `pii`.
   - `drop_if_topic_missing: true` and `default_topic: "narrative"`.
-- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `hivemind_memory_yyyymmdd-ThhmmssZ.json`.
+- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` (e.g., `agi-agi-memory-ab12cd-20250926-T192000Z.json`).
+- When no identity is detected, HiveMind falls back to `hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` to ensure the export is still traceable.
+- AGI variants follow this convention, producing names such as `agi-agi-memory-<shortsum>-yyyymmdd-ThhmmssZ.json`, `alice-agi-memory-<shortsum>-yyyymmdd-ThhmmssZ.json`, or `external-agi-memory-<shortsum>-yyyymmdd-ThhmmssZ.json`.
 - Export prompts enter thinking mode, stay bound to the paused HiveMind session, and when `--code` is active they print the inline block before asking if a download link is still required.
 
 **Identity binding:**


### PR DESCRIPTION
## Summary
- document the hyphenated identity-owner memory export filename template
- describe the HiveMind fallback naming and list AGI-specific examples

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d905b694dc8320b4aaff33aaf9a024