### PR TITLE
Add aci_repo reference to nexus core

### DIFF
--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -22,6 +22,7 @@
     },
     "references": {
       "bifrost": "entities/bifrost/bifrost.json",
+      "aci_repo": "entities/aci_repo/aci_repo.json",
       "github_connector": "connectors/github_connector.json"
     },
     "resolution_policy": {


### PR DESCRIPTION
## Summary
- add the aci_repo manifest to the nexus_core references list so it is grouped with the other universal anchors

## Testing
- python -m json.tool entities/nexus_core/nexus_core.json

------
https://chatgpt.com/codex/tasks/task_e_68d915b5467c8320b4c8f7da3874bf64