### PR TITLE
Add aci_repo reference to GitHub connector

### DIFF
--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -26,6 +26,7 @@
       ]
     },
     "references": {
+      "aci_repo": "entities/aci_repo/aci_repo.json",
       "bifrost": "entities/bifrost/bifrost.json"
     },
     "aci_resolution_instruction": {


### PR DESCRIPTION
## Summary
- add the aci_repo entity mapping to the GitHub connector references

## Testing
- python -m json.tool connectors/github_connector.json

------
https://chatgpt.com/codex/tasks/task_e_68d915b249608320a997cd6974cb4b57