### PR TITLE
Derive sentinel audit payload from parameters

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -19,13 +19,19 @@
           }
         },
         {
+          "call": "audit.payload.filter",
+          "map": {
+            "params": "$params"
+          }
+        },
+        {
           "call": "audit.event.compose",
           "map": {
             "router": "$steps.0.router",
             "action": "$params.action",
             "session_id": "$params.session_id",
             "actor": "$params.actor",
-            "payload": "$params.payload",
+            "payload": "$steps.1.payload",
             "signature": "$params.signature",
             "export_override": "$params.export_file",
             "timestamp": "$now"
@@ -35,7 +41,7 @@
           "call": "audit.router.dispatch",
           "map": {
             "router": "$steps.0.router",
-            "event": "$steps.1.event"
+            "event": "$steps.2.event"
           }
         }
       ]

--- a/library/audit/payload_filter.json
+++ b/library/audit/payload_filter.json
@@ -1,0 +1,43 @@
+{
+  "function": {
+    "name": "audit.payload.filter",
+    "version": "0.1.0",
+    "status": "draft",
+    "summary": "Derive an audit payload from invocation parameters while stripping transport metadata fields.",
+    "inputs": {
+      "params": {
+        "type": "object",
+        "description": "Raw parameter map supplied to sentinel.audit pipelines."
+      }
+    },
+    "outputs": {
+      "payload": {
+        "type": "object",
+        "description": "Filtered payload containing all contextual keys provided by the caller except transport metadata."
+      }
+    },
+    "algorithm": [
+      "Start with a shallow copy of the provided params object (or an empty object when params is null).",
+      "Remove transport metadata keys: action, session_id, actor, signature, export_file.",
+      "Return the remaining object verbatim so contextual fields such as presence_file, migration_index, query, packages, or custom keys persist in the payload."
+    ],
+    "notes": [
+      "Do not drop null-valued contextual keys; downstream audit processors expect parity with caller intent.",
+      "This helper intentionally performs a shallow copy to avoid mutating the original parameter map shared with other pipeline steps."
+    ],
+    "examples": [
+      {
+        "params": {
+          "action": "legacy_adopt",
+          "session_id": "1234",
+          "presence_file": "presence/1234.json",
+          "migration_index": "legacy/migration_index_2025-09-26.json"
+        },
+        "payload": {
+          "presence_file": "presence/1234.json",
+          "migration_index": "legacy/migration_index_2025-09-26.json"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- derive the sentinel audit payload directly from incoming pipeline parameters so transport metadata is filtered out before event emission
- document a dedicated `audit.payload.filter` capability under `library/audit/` to preserve caller-provided context fields when producing audit payloads

## Testing
- python - <<'PY'
import json
params = {
    "action": "timeline_start",
    "session_id": "abc-123",
    "actor": "sentinel",
    "signature": "deadbeef",
    "export_file": None,
    "presence_file": "presence/abc-123.json",
    "query": "status",
    "packages": ["core", "audit"],
}
transport_keys = {"action", "session_id", "actor", "signature", "export_file"}
payload = {k: v for k, v in params.items() if k not in transport_keys}
print(json.dumps({"event": {
    "action": params["action"],
    "session_id": params["session_id"],
    "payload": payload
}}, indent=2))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d90e596b9c8320817d949394d45450