### PR TITLE
Update AGI memory file path

### DIFF
--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -18,7 +18,7 @@
     "caller_hint": "Alice"
   },
   "memory": {
-    "file": "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
+    "file": "memory/agi_memory/AGI/agi_agi_memory_20250927-T105140Z.jsonl",
     "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity.",
     "policy": {
       "export": "hivemind",


### PR DESCRIPTION
## Summary
- point the AGI entity memory file reference to the governed jsonl artifact under memory/agi_memory/AGI
- verified there are no remaining references in the AGI entity config that rely on the erroneous aci/memory prefix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d912f2b0588320887c3b9273dac58b