### PR TITLE
Normalize identity usage in hivemind export templates

### DIFF
--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -16,9 +16,9 @@
     "note": null
   },
   "output": {
-    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
+    "memory_path_template": "aci/memory/agi_memory/${IDENTITY_LOWER}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
     "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY}/adapters/",
-    "manifest_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
+    "manifest_template": "aci/memory/agi_memory/${IDENTITY_LOWER}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -14,7 +14,7 @@
     "note": null
   },
   "output": {
-    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
+    "memory_path_template": "aci/memory/agi_memory/${IDENTITY_LOWER}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false


### PR DESCRIPTION
## Summary
- ensure hivemind session export memory paths use the lowercase identity in both directory and filename prefix
- align the full bundle export configuration to reference the lowercase identity consistently and avoid uppercase concatenation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d912f2be608320b1b8ec801ce29667