### PR TITLE
docs: keep hivemind export guidance on --codebox flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ Capability chaining: pipeline identifiers (e.g., aci.memory.export.hivemind, agi
 Schema: hivemind_agi_memory for AGI-owned narratives; topic/deny filters enforced via /entities/agi/agi_export_policy.json.
 Filename template: {identity_lower}_agi_memory_{timestamp}.json with timestamp formatted as Ymd-THMSZ.
 CLI usage:
-hivemind export agi --identity AGI --code --force
-hivemind export agi --identity Alice --code --force
+hivemind export agi --identity AGI --codebox --force
+hivemind export agi --identity Alice --codebox --force
 Export guarantees: chronological ordering, audit logging, privacy filters, and normalization to UTC Z timestamps.
 8) Lifecycle of an Entity
 Create: register identity, add config under /entities/<name>/, ensure governance hooks, and keep capabilities stateless.

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 
 ```bash
 # AGI narrative export (observer POV)
-hivemind export agi --identity AGI --code --force
+hivemind export agi --identity AGI --codebox --force
 
 # Alice session export
-hivemind export agi --identity Alice --code --force
+hivemind export agi --identity Alice --codebox --force
 
 # Optional summary slug example (sanitized to `_launch_review`)
 hivemind export session --summary "Launch Review" --download

--- a/entities/agi/agi_tools/autolearn.json
+++ b/entities/agi/agi_tools/autolearn.json
@@ -117,8 +117,8 @@
       {
         "call": "chat.deliver",
         "map": {
-          "message": "Auto-learn mode paused. Run 'hivemind export AGI --code --identity=${active_identity}' to export the session?",
-          "suggested_command": "hivemind export AGI --code --identity=${active_identity}"
+          "message": "Auto-learn mode paused. Run 'hivemind export AGI --codebox --identity=${active_identity}' to export the session?",
+          "suggested_command": "hivemind export AGI --codebox --identity=${active_identity}"
         }
       }
     ]


### PR DESCRIPTION
## Summary
- revert documentation updates that suggested the unsupported `--code` flag for hivemind exports
- restore the autolearn pause prompt to recommend `--codebox` to match the current CLI

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d90dd81610832080c2570c6f0e0f5c