### PR TITLE
Align hivemind export templates with identity directories

### DIFF
--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -16,9 +16,9 @@
     "note": null
   },
   "output": {
-    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
+    "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
     "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY}/adapters/",
-    "manifest_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
+    "manifest_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -14,7 +14,7 @@
     "note": null
   },
   "output": {
-    "memory_path_template": "aci/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
+    "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false


### PR DESCRIPTION
## Summary
- update hivemind session export output path to use the identity directory while keeping the lowercase filename prefix
- align the full bundle export memory and manifest templates with the same directory and filename convention
- confirm no other EEC templates changed their directory identity casing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91ad65be883208103174adfbe7643