### PR TITLE
Align AGI memory reference with governed artifact

### DIFF
--- a/entities/agi/README_ENTITY.txt
+++ b/entities/agi/README_ENTITY.txt
@@ -10,7 +10,7 @@ PURPOSE: Deterministic operating contract for AGI + AGI Proxy under ACI governan
 
 1) REQUIRED PATHS
 - AGI spec:                    aci/entities/agi/agi.json
-- AGI memory (locked):         aci/memory/agi_memory/AGI/agi_agi_memory_yyyymmdd-ThhmmssZ.json
+- AGI memory (locked):         ./memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json (verified local artifact)
 - AGI Proxy spec:              aci/entities/agi_proxy/agi_proxy.json
 - EEC base:                    aci/entities/agi_proxy/eec/eec_base.json
 - EEC presets:                 aci/entities/agi_proxy/eec/*.json

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -18,7 +18,7 @@
     "caller_hint": "Alice"
   },
   "memory": {
-    "file": "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
+    "file": "./memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
     "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity.",
     "policy": {
       "export": "hivemind",


### PR DESCRIPTION
## Summary
- point the AGI entity memory reference to the verified governed audit artifact using an explicit relative path
- document the verified artifact path in the AGI entity README for clarity

## Testing
- ls ./memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json

------
https://chatgpt.com/codex/tasks/task_e_68d91aab410083209028faad580993dd