### PR TITLE
Restore AGI memory file path reference

### DIFF
--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -18,7 +18,7 @@
     "caller_hint": "Alice"
   },
   "memory": {
-    "file": "./memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
+    "file": "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
     "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity.",
     "policy": {
       "export": "hivemind",


### PR DESCRIPTION
## Summary
- point the AGI entity memory reference back to the governed audit artifact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92823b9208320ad267bdc9c4a1812