### PR TITLE
Add canonical identity directory templates for HIVEMind exports

### DIFF
--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -16,6 +16,7 @@
     "note": null
   },
   "output": {
+    "memory_directory_template": "/memory/agi_memory/${IDENTITY}/",
     "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
     "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY}/adapters/",
     "manifest_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -14,6 +14,7 @@
     "note": null
   },
   "output": {
+    "memory_directory_template": "/memory/agi_memory/${IDENTITY}/",
     "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {


### PR DESCRIPTION
## Summary
- add explicit memory directory templates that use the canonical ${IDENTITY} folder for session and full hivemind exports
- keep existing lowercase filename prefixes while making the identity directory path available to downstream consumers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9242fad7c8320920af260d44ccb1b