### PR TITLE
Normalize identity directory placeholders in hivemind export configs

### DIFF
--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -4,6 +4,7 @@
   "description": "Produce a full AGI-local export bundle (session hivemind slice + artifacts + signed manifest) under AGI memory.",
   "inputs": {
     "identity": "${IDENTITY}",
+    "identity_directory": "${IDENTITY}",
     "session_id": "${SESSION_ID}",
     "source_jobs": ["${JOB_ID}"],
     "include_chatlogs": true,
@@ -16,10 +17,10 @@
     "note": null
   },
   "output": {
-    "memory_directory_template": "/memory/agi_memory/${IDENTITY}/",
-    "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
-    "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY}/adapters/",
-    "manifest_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
+    "memory_directory_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/",
+    "memory_path_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
+    "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY_DIRECTORY}/adapters/",
+    "manifest_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -4,6 +4,7 @@
   "description": "Produce a session-level hivemind slice and write it into AGI memory (no external hivemind changes).",
   "inputs": {
     "identity": "${IDENTITY}",
+    "identity_directory": "${IDENTITY}",
     "session_id": "${SESSION_ID}",
     "include_chatlogs": true,
     "include_weights_meta": true,
@@ -14,8 +15,8 @@
     "note": null
   },
   "output": {
-    "memory_directory_template": "/memory/agi_memory/${IDENTITY}/",
-    "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
+    "memory_directory_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/",
+    "memory_path_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {
     "internet": false


### PR DESCRIPTION
## Summary
- add an explicit `identity_directory` input for hivemind session and full export EEC jobs
- update memory and manifest templates to reference the uppercase-preserving directory placeholder
- align the full export bundle artifact directory with the new identity directory placeholder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92b187450832090538e7ddf9f08f7