### PR TITLE
Document hyphen-based HiveMind AGI export default

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -26,7 +26,8 @@
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
-        "output_default": "agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
+        "output_default": "agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json",
+        "notes": "Default filename template uses hyphen separators only"
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- document the hyphen-only filename template for `hivemind export agi`
- add a notes field to the help output so the hyphenated default is explicit

## Testing
- rg '_memory_' entities/hivemind/hivemind.json

------
https://chatgpt.com/codex/tasks/task_e_68d91ae290d083209b27252a667d0d6b