### PR TITLE
Clarify AGI memory path notes

### DIFF
--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -19,7 +19,7 @@
   },
   "memory": {
     "file": "memory/agi_memory/AGI/agi_agi_memory_20250927-T105140Z.jsonl",
-    "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity.",
+    "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity. Repository paths drop the aci/ prefix to match on-disk layout.",
     "policy": {
       "export": "hivemind",
       "lock_namespace": "AGI",


### PR DESCRIPTION
## Summary
- document in the AGI entity manifest that memory artifacts are referenced without the `aci/` prefix so the paths reflect the repository layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d92ee8f67c83209aace4c0b533bf9f