### PR TITLE
Update Sentinel audit export overrides

### DIFF
--- a/entities/sentinel/sentinel.json
+++ b/entities/sentinel/sentinel.json
@@ -7,12 +7,12 @@
   "audit": {
     "router_config": "library/audit/audit_router.json",
     "default_mode": "session_only",
-    "export_instruction": "Provide \"export_file\": true when invoking pipelines.sentinel.audit to generate a persistent export alongside the session log."
+    "export_instruction": "Set \"export_override\" to the router sink key (e.g., audit_router.tracehub.export or audit_router.tva_ledger.export) when invoking pipelines.sentinel.audit to promote a governed export alongside the session log."
   },
   "guidance": [
     "Session-only logging keeps activity confined to /memory/audit/ for the active runtime window.",
-    "Persistent exports require the export sink to be enabled and will emit governed JSONL files under /memory/audit/exports/.",
-    "Signature enforcement follows the router controls; when export_file mode is active, presence records must include a valid Sentinel/ALIAS signature."
+    "Persistent exports require the export sink mode to be enabled and must specify the matching audit_router.<sink>.export override when promotion is approved.",
+    "Signature enforcement follows the router controls; when an export override is requested, presence records must include a valid Sentinel/ALIAS signature."
   ],
   "changelog": [
     {

--- a/functions.json
+++ b/functions.json
@@ -33,7 +33,7 @@
             "actor": "$params.actor",
             "payload": "$steps.1.payload",
             "signature": "$params.signature",
-            "export_override": "$params.export_file",
+            "export_override": "$params.export_override",
             "timestamp": "$now"
           }
         },

--- a/library/audit/payload_filter.json
+++ b/library/audit/payload_filter.json
@@ -1,7 +1,7 @@
 {
   "function": {
     "name": "audit.payload.filter",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "status": "draft",
     "summary": "Derive an audit payload from invocation parameters while stripping transport metadata fields.",
     "inputs": {
@@ -18,7 +18,7 @@
     },
     "algorithm": [
       "Start with a shallow copy of the provided params object (or an empty object when params is null).",
-      "Remove transport metadata keys: action, session_id, actor, signature, export_file.",
+      "Remove transport metadata keys: action, session_id, actor, signature, export_override.",
       "Return the remaining object verbatim so contextual fields such as presence_file, migration_index, query, packages, or custom keys persist in the payload."
     ],
     "notes": [


### PR DESCRIPTION
## Summary
- accept router sink override keys when composing Sentinel audit events
- document export override usage across the payload filter and Sentinel guidance

## Testing
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68d92f53fe688320aac5875409916a91