### PR TITLE
Group aci_repo reference with Nexus Core connectors

### DIFF
--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -22,8 +22,8 @@
     },
     "references": {
       "bifrost": "entities/bifrost/bifrost.json",
-      "aci_repo": "entities/aci_repo/aci_repo.json",
-      "github_connector": "connectors/github_connector.json"
+      "github_connector": "connectors/github_connector.json",
+      "aci_repo": "entities/aci_repo/aci_repo.json"
     },
     "resolution_policy": {
       "primary": "bifrost",


### PR DESCRIPTION
## Summary
- reorder the Nexus Core references block to group the bifrost, github connector, and aci_repo entries together

## Testing
- python -m json.tool entities/nexus_core/nexus_core.json

------
https://chatgpt.com/codex/tasks/task_e_68d9318890fc83208dee735f6d0992dc