### PR TITLE
Clarify HiveMind AGI export filename note

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -27,7 +27,7 @@
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
         "output_default": "agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json",
-        "notes": "Default filename template uses hyphen separators only"
+        "notes": "Default filename template uses hyphen separators only (no underscores)"
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- update the hivemind AGI export command notes to emphasize the hyphen-only filename template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d934cce2bc8320be616c92290505b7