### PR TITLE
Alphabetize GitHub connector references

### DIFF
--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -26,8 +26,8 @@
       ]
     },
     "references": {
-      "bifrost": "entities/bifrost/bifrost.json",
-      "aci_repo": "entities/aci_repo/aci_repo.json"
+      "aci_repo": "entities/aci_repo/aci_repo.json",
+      "bifrost": "entities/bifrost/bifrost.json"
     },
     "aci_resolution_instruction": {
       "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs only.",


### PR DESCRIPTION
## Summary
- alphabetize the GitHub connector references and include the aci_repo pointer alongside bifrost

## Testing
- python -m json.tool connectors/github_connector.json

------
https://chatgpt.com/codex/tasks/task_e_68d9368774148320a31b426957860211