### PR TITLE
Document AGI export hyphenated default

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -27,7 +27,7 @@
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
         "output_default": "agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json",
-        "notes": "Default filename template uses hyphen separators only (no underscores); pattern agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json."
+        "notes": "Hyphen-only default filename: agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json."
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- emphasize the hyphen-only filename template for the `hivemind export agi` command notes

## Testing
- rg '_memory_' entities/hivemind/hivemind.json

------
https://chatgpt.com/codex/tasks/task_e_68d944f9b6f88320b905efc300b39bd4