### PR TITLE
Clarify hyphenated HiveMind AGI export default

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -27,7 +27,7 @@
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
         "output_default": "agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json",
-        "notes": "Default filename template uses hyphen separators only (no underscores)."
+        "notes": "Default filename template updated to agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json with hyphen separators only (no underscores)."
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- ensure the HiveMind AGI export help entry references the hyphenated default filename template

## Testing
- rg 'output_default": ".*_'' entities/hivemind/hivemind.json

------
https://chatgpt.com/codex/tasks/task_e_68d944f85efc8320ad0de747279d88fb