### PR TITLE
Normalize migrate_to_jsonl entity handling

### DIFF
--- a/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
+++ b/entities/agi/agi_tools/migrate_to_jsonl/test_migrate.py
@@ -6,6 +6,7 @@ import datetime as dt
 import json
 import importlib.util
 from pathlib import Path
+import tempfile
 import unittest
 
 
@@ -197,9 +198,53 @@ class ArchivedMigratorPathResolutionTests(unittest.TestCase):
 
         module.validate_line(entry)
 
+        self.assertEqual(entry["entity"], "Legacy Actor")
         self.assertEqual(entry["identity"], "Legacy Actor")
         self.assertNotIn("actor", entry)
         self.assertEqual(entry["metadata"].get("legacy_identity_key"), "actor")
+
+    def test_migrate_file_outputs_entity_field(self) -> None:
+        module = self.module
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_dir = Path(tmpdir)
+            input_path = temp_dir / "legacy.json"
+            output_dir = temp_dir / "out"
+            payload = {
+                "messages": [
+                    {
+                        "timestamp": "2024-01-01T00:00:00Z",
+                        "role": "assistant",
+                        "content": "hello",
+                        "metadata": {"topic": "analysis"},
+                    }
+                ]
+            }
+            with input_path.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle)
+
+            repo_root = Path(__file__).resolve().parents[4]
+            identity_path = repo_root / "entities/agi/agi_identity_manager.json"
+            policy_path = repo_root / "entities/agi/agi_export_policy.json"
+            identity = module.load_identity(identity_path)
+            policy = module.load_policy(policy_path)
+
+            output_path = module.migrate_file(
+                input_path,
+                output_dir=output_dir,
+                identity=identity,
+                policy=policy,
+                default_topic="analysis",
+            )
+
+            self.assertIsNotNone(output_path)
+            assert output_path is not None
+            with output_path.open("r", encoding="utf-8") as handle:
+                rows = [json.loads(line) for line in handle if line.strip()]
+
+            self.assertGreaterEqual(len(rows), 1)
+            for row in rows:
+                self.assertIn("entity", row)
+                self.assertEqual(row.get("entity"), row.get("identity"))
 
     def test_validate_line_promotes_agent_identity(self) -> None:
         module = self.module


### PR DESCRIPTION
## Summary
- require the archived migrator to populate the `entity` field from legacy aliases before validation while mirroring the legacy key into metadata
- emit `entity` in migrated JSONL rows and adjust deduplication to rely on it alongside an optional `identity` field for compatibility
- add a regression test that runs the migrator on a sample payload and asserts the exported rows include `entity`

## Testing
- python -m unittest entities.agi.agi_tools.migrate_to_jsonl.test_migrate

------
https://chatgpt.com/codex/tasks/task_e_68d95a60b2ec8320b6647c8d0b91c8da