### PR TITLE
Clarify hivemind export agi defaults

### DIFF
--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -27,7 +27,7 @@
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
         "output_default": "agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json",
-        "notes": "Default filename template updated to agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json with hyphen separators only (no underscores)."
+        "notes": "Default filename template updated to agi-{identity|-fallback}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json with hyphen separators only (no underscores); validated that no underscore-based defaults remain in this block."
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- confirm the hivemind AGI export default filename uses the hyphenated pattern
- note that the command block has been checked to ensure no underscore-based defaults remain

## Testing
- rg 'output_default" : ".*_" -n entities/hivemind/hivemind.json

------
https://chatgpt.com/codex/tasks/task_e_68d959f0931883209169360ca5985eae