### PR TITLE
Fix hivemind export directory casing

### DIFF
--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -17,7 +17,7 @@
     "note": null
   },
   "output": {
-    "memory_directory_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/",
+    "memory_directory_template": "/memory/agi_memory/${IDENTITY}/",
     "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.${FORMAT}",
     "bundle_artifact_dir": "aci/entities/agi/identities/${IDENTITY_DIRECTORY}/adapters/",
     "manifest_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -15,7 +15,7 @@
     "note": null
   },
   "output": {
-    "memory_directory_template": "/memory/agi_memory/${IDENTITY_DIRECTORY}/",
+    "memory_directory_template": "/memory/agi_memory/${IDENTITY}/",
     "memory_path_template": "/memory/agi_memory/${IDENTITY}/${IDENTITY_LOWER}_agi_memory_${DATE}-T${TIME}Z.json"
   },
   "sandbox_overrides": {


### PR DESCRIPTION
## Summary
- align the hivemind session export directory template with the canonical identity casing
- ensure the full hivemind export uses the canonical identity directory while keeping lowercase filenames

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9627375208320819352ceea4d8f03