### PR TITLE
Align HiveMind export docs with identity-aware naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ hivemind export agi --identity Alice --jsonl --code --force
   - `allow_topics`: `session_start`, `session_end`, `intent`, `narrative`, `analysis`, `artifact`, `validation`, `decision`, `policy`, `policy_update`, `diff`, `patch`, `export`, `obstacle`, `next_steps`, `commit`.
   - `deny_tags`: `secret`, `credential`, `token`, `api_key`, `password`, `runtime_secret`, `private_key`, `raw_text`, `internal_path`, `pii`.
   - `drop_if_topic_missing: true` and `default_topic: "narrative"`.
-- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `hivemind_memory_yyyymmdd-ThhmmssZ.json`.
+- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the identity-aware pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`.
+  - If no identity is detected for the session, HiveMind falls back to `hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`.
+  - AGI exports follow the same template, with examples such as `agi-agi-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`, `alice-agi-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`, and `external-agi-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`.
 - Export prompts enter thinking mode, stay bound to the paused HiveMind session, and when `--code` is active they print the inline block before asking if a download link is still required.
 
 **Identity binding:**

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -18,7 +18,7 @@
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "--jsonl (line-delimited JSON persisted as .json), --download (persist to file), --code (render in chat code fence), --slice:<type> (session_only/full/range:<ts>/entity:<name>), --force (pause + export even if safeguards protest)",
         "description": "Exports the current HiveMind session snapshot with TVA + Sentinel oversight",
-        "output_default": "hivemind_memory_yyyymmdd-ThhmmssZ.json"
+        "output_default": "[identity-]hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
       },
       {
         "command": "hivemind export agi",
@@ -26,7 +26,7 @@
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "Delegates to AGI export policies; see entities/agi/agi.json for schema.",
         "description": "Invokes the AGI-managed export pipeline under HiveMind governance",
-        "output_default": "agi_memory/<identity>/<identity>_agi_memory_yyyymmdd-ThhmmssZ.json"
+        "output_default": "agi-agi-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
       },
       {
         "command": ":hivemind help",


### PR DESCRIPTION
## Summary
- document the identity-aware export filename pattern for HiveMind and AGI variants in the README
- update HiveMind CLI metadata defaults to reflect the new short checksum-based naming templates

## Testing
- not run (documentation-only)


------
https://chatgpt.com/codex/tasks/task_e_68d831e515fc8320aed9cb11e460da99