### PR TITLE
Align HiveMind session export defaults with hyphenated filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ hivemind export agi --identity Alice --jsonl --code --force
   - `allow_topics`: `session_start`, `session_end`, `intent`, `narrative`, `analysis`, `artifact`, `validation`, `decision`, `policy`, `policy_update`, `diff`, `patch`, `export`, `obstacle`, `next_steps`, `commit`.
   - `deny_tags`: `secret`, `credential`, `token`, `api_key`, `password`, `runtime_secret`, `private_key`, `raw_text`, `internal_path`, `pii`.
   - `drop_if_topic_missing: true` and `default_topic: "narrative"`.
-- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` (e.g., `agi-agi-memory-ab12cd-20250926-T192000Z.json`). When no identity is detected, HiveMind falls back to `hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json`. AGI-owned exports typically appear as `agi-agi-memory-…`, `alice-agi-memory-…`, or `external-agi-memory-…` variants.
+- Defaults apply `--download --jsonl --code --force`. JSONL payloads are saved with a `.json` extension using the naming pattern `{identity}-{owner module}-memory-{shortsum}-yyyymmdd-ThhmmssZ.json` (e.g., `agi-agi-memory-ab12cd-20250926-T192000Z.json`). When no identity is detected, HiveMind falls back to `hivemind_memory-yyyymmddThhmmssZ.json`, matching the hyphenated log filenames in `/memory/hivemind_memory/logs/`. AGI-owned exports typically appear as `agi-agi-memory-…`, `alice-agi-memory-…`, or `external-agi-memory-…` variants.
 - Export prompts enter thinking mode, stay bound to the paused HiveMind session, and when `--code` is active they print the inline block before asking if a download link is still required.
 
 **Identity binding:**

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -18,7 +18,7 @@
         "default_parameter": "--download --jsonl --code --force",
         "parameters": "--jsonl (line-delimited JSON persisted as .json), --download (persist to file), --code (render in chat code fence), --slice:<type> (session_only/full/range:<ts>/entity:<name>), --force (pause + export even if safeguards protest)",
         "description": "Exports the current HiveMind session snapshot with TVA + Sentinel oversight",
-        "output_default": "{identity|-fallback}-hivemind-memory-{shortsum}-yyyymmdd-ThhmmssZ.json"
+        "output_default": "hivemind_memory-yyyymmddThhmmssZ.json"
       },
       {
         "command": "hivemind export agi",


### PR DESCRIPTION
## Summary
- document the hyphenated default HiveMind export filename in the README
- align the `hivemind export session` default filename template with the hyphenated pattern

## Testing
- rg --line-number "hivemind_memory"

------
https://chatgpt.com/codex/tasks/task_e_68d98345cf688320b512ffb468559c29