### PR TITLE
Document export storage fallback rule across entity procedures

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -21,6 +21,7 @@
         }
       ]
     },
+    "export_fallback_rule": "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)",
     "list": [
       {
         "id": 0,

--- a/entities/tracehub/tracehub.json
+++ b/entities/tracehub/tracehub.json
@@ -43,7 +43,8 @@
     "procedure": [
       "1) Flush session buffers to the session_path and compute SHA-256 manifests.",
       "2) Raise the audit_router.tracehub.export flag and copy approved entries to export_path with TVA seal metadata (ledger id, approver, timestamp).",
-      "3) Update TVA ledger with export manifest reference, drop the export flag, and release TraceHub writers."
+      "3) Update TVA ledger with export manifest reference, drop the export flag, and release TraceHub writers.",
+      "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)"
     ],
     "notes": "Use audit router toggle_semantics to switch store_in targets from audit_router.tracehub.session to audit_router.tracehub.export when fulfilling user export requests."
   }

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -66,8 +66,8 @@
       "procedure": [
         "1) Review session_path entries for scope and redact as required.",
         "2) Raise the audit_router.tva_ledger.export flag and move approved entries to export_path with TVA seal and checksum manifest.",
-        "3) Emit export notice to TraceHub, update ALIAS governance register with manifest reference, and drop the export flag once the ledger is sealed."
-        "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)", 
+        "3) Emit export notice to TraceHub, update ALIAS governance register with manifest reference, and drop the export flag once the ledger is sealed.",
+        "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)"
       ],
       "notes": "Toggle audit router targets from audit_router.tva_ledger.session to audit_router.tva_ledger.export only after approvals are logged; revert once export is sealed."
     },


### PR DESCRIPTION
## Summary
- add the storage fallback rule to the global entities manifest for shared export guidance
- extend TraceHub manual export procedures with the governed fallback sequence
- normalize the TVA manual export step to avoid trailing comma while keeping the fallback rule intact

## Testing
- jq empty entities.json
- jq empty entities/tracehub/tracehub.json
- jq empty entities/tva/tva.json

------
https://chatgpt.com/codex/tasks/task_e_68da3e5cce4883208865c3f5a8fdc107