### PR TITLE
Remove aci_repo reference from GitHub connector

### DIFF
--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -26,8 +26,7 @@
       ]
     },
     "references": {
-      "bifrost": "entities/bifrost/bifrost.json",
-      "aci_repo": "entities/aci_repo/aci_repo.json"
+      "bifrost": "entities/bifrost/bifrost.json"
     },
     "aci_resolution_instruction": {
       "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs only.",


### PR DESCRIPTION
## Summary
- remove the aci_repo entry from the GitHub connector references so only bifrost remains

## Testing
- python -m json.tool connectors/github_connector.json

------
https://chatgpt.com/codex/tasks/task_e_68da4b5775848320b52fc770ba2a2e5c