### PR TITLE
Remove nexus_core reference from Bifrost

### DIFF
--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -8,8 +8,7 @@
         "abstract": "Bridges internal ACI routing to external connectors; maintains a minimal allowlist for direct connector refs.",
         "knowledge_base": "connector orchestration & resolvers",
         "references": {
-            "github_connector": "connectors/github_connector.json",
-            "nexus_core": "entities/nexus_core/nexus_core.json"
+            "github_connector": "connectors/github_connector.json"
         },
         "connector_binding": {
             "key": "github_connector",


### PR DESCRIPTION
## Summary
- remove the nexus_core reference from the Bifrost entity manifest so only the GitHub connector remains listed

## Testing
- python -m json.tool entities/bifrost/bifrost.json

------
https://chatgpt.com/codex/tasks/task_e_68da4e21f37083209de30dfcf695f308