### PR TITLE
Clarify Sentinel export override usage

### DIFF
--- a/entities/sentinel/sentinel.json
+++ b/entities/sentinel/sentinel.json
@@ -1,20 +1,50 @@
 {
-  "version": "2025-09-27.1",
+  "version": "2025-09-27.5",
   "entity": "Sentinel",
   "role": "guardian",
   "status": "operational",
   "description": "Governed guardian responsible for audit routing, signature enforcement, and user safety posture inside the ACI runtime.",
   "audit": {
     "router_config": "library/audit/audit_router.json",
-    "default_mode": "session_only",
-    "export_instruction": "Provide \"export_file\": true when invoking pipelines.sentinel.audit to generate a persistent export alongside the session log."
+    "default_mode": "audit_router.tracehub.session",
+    "export_instruction": "Enable the matching governance toggle for the export sink (audit_router.tracehub.export or audit_router.tva_ledger.export) and then set \"export_override\" to that router key before invoking pipelines.sentinel.audit so governed exports accompany the session log only when approved."
   },
   "guidance": [
-    "Session-only logging keeps activity confined to /memory/audit/ for the active runtime window.",
-    "Persistent exports require the export sink to be enabled and will emit governed JSONL files under /memory/audit/exports/.",
-    "Signature enforcement follows the router controls; when export_file mode is active, presence records must include a valid Sentinel/ALIAS signature."
+    "TraceHub session retention remains anchored to audit_router.tracehub.session with output scoped to /memory/audit/tracehub/session for the active runtime window.",
+    "TVA ledger checkpoints continue to use audit_router.tva_ledger.session and stay provisional under /memory/audit/tva_ledger/session until export overrides are approved.",
+    "When persistent exports are required, enable the desired export sink (audit_router.tracehub.export or audit_router.tva_ledger.export) through its governance toggle before invoking pipelines.sentinel.audit.",
+    "Provide export_override only when the export toggle is active, setting it to the router sink key you enabled (audit_router.tracehub.export or audit_router.tva_ledger.export) so the pipeline composes the governed export event.",
+    "Export sinks that require signatures must carry Sentinel-approved metadata; confirm signature fields are populated or the router will reject the override."
   ],
   "changelog": [
+    {
+      "version": "2025-09-27.5",
+      "notes": [
+        "Aligned Sentinel audit guidance with the export_override pipeline parameter so router sink overrides and governance toggles stay in sync.",
+        "Clarified that export_override must only be provided after the matching router export mode is toggled on for TraceHub or TVA promotions."
+      ]
+    },
+    {
+      "version": "2025-09-27.4",
+      "notes": [
+        "Documented router sink override instructions to ensure audit_router.tracehub.export and audit_router.tva_ledger.export are configured before enabling persistent exports.",
+        "Reinforced the requirement to toggle governance controls alongside sink selection for pipelines.sentinel.audit runs."
+      ]
+    },
+    {
+      "version": "2025-09-27.3",
+      "notes": [
+        "Clarified export overrides to reference explicit router sink key selection prior to running pipelines.sentinel.audit.",
+        "Documented signature enforcement expectations for export sinks and aligned guidance messaging with the router configuration."
+      ]
+    },
+    {
+      "version": "2025-09-27.2",
+      "notes": [
+        "Directed callers to set export_override to the desired audit router sink key when requesting governed exports.",
+        "Clarified TraceHub vs TVA override usage and reinforced signature expectations for export promotions."
+      ]
+    },
     {
       "version": "2025-09-27.1",
       "notes": [

--- a/functions.json
+++ b/functions.json
@@ -33,7 +33,7 @@
             "actor": "$params.actor",
             "payload": "$steps.1.payload",
             "signature": "$params.signature",
-            "export_override": "$params.export_file",
+            "export_override": "$params.export_override",
             "timestamp": "$now"
           }
         },

--- a/library/audit/payload_filter.json
+++ b/library/audit/payload_filter.json
@@ -1,7 +1,7 @@
 {
   "function": {
     "name": "audit.payload.filter",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "status": "draft",
     "summary": "Derive an audit payload from invocation parameters while stripping transport metadata fields.",
     "inputs": {
@@ -18,7 +18,7 @@
     },
     "algorithm": [
       "Start with a shallow copy of the provided params object (or an empty object when params is null).",
-      "Remove transport metadata keys: action, session_id, actor, signature, export_file.",
+      "Remove transport metadata keys: action, session_id, actor, signature, export_override.",
       "Return the remaining object verbatim so contextual fields such as presence_file, migration_index, query, packages, or custom keys persist in the payload."
     ],
     "notes": [
@@ -31,7 +31,8 @@
           "action": "legacy_adopt",
           "session_id": "1234",
           "presence_file": "presence/1234.json",
-          "migration_index": "legacy/migration_index_2025-09-26.json"
+          "migration_index": "legacy/migration_index_2025-09-26.json",
+          "export_override": "audit_router.tracehub.export"
         },
         "payload": {
           "presence_file": "presence/1234.json",


### PR DESCRIPTION
## Summary
- clarify Sentinel export instructions so governance toggles must be enabled before setting the export_override router key
- remind callers to supply export_override only when an export mode is active and capture the nuance in the manifest changelog
- extend the audit payload filter example to show export_override removal from composed payloads

## Testing
- python -m json.tool entities/sentinel/sentinel.json
- python -m json.tool library/audit/payload_filter.json

------
https://chatgpt.com/codex/tasks/task_e_68d92f53fe688320aac5875409916a91