### PR TITLE
Add jsDelivr mirrors to canonical resolution policies

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -26,8 +26,11 @@
       "canonical_source": "github",
       "repo": "aliasnet/aci",
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+      ],
       "priority": "canonical_raw_over_local",
-      "notes": "Canonical raw URLs take precedence over local copies; use local files only if the mirror cannot be reached."
+      "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; use local files only if the canonical sources cannot be reached."
     },
     "initialization_sequence": [
       {

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -22,6 +22,9 @@
       "canonical_source": "github",
       "repo": "aliasnet/aci",
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+      ],
       "fallbacks": [
         {
           "key": "local_cache",
@@ -105,7 +108,7 @@
       "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; fall back to local only if the remote mirror is unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
+    "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; fall back to local only if the canonical sources are unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
     "cognitive_decision_guidance": {
       "version": "1.0",
       "scope": "universal",

--- a/alias.json
+++ b/alias.json
@@ -50,7 +50,10 @@
     "canonical_source": "github",
     "repo": "aliasnet/aci",
     "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+    "mirrors": [
+      "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+    ],
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; use local registry data only if the mirror is unreachable."
+    "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; use local registry data only if the canonical sources are unreachable."
   }
 }

--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -11,13 +11,18 @@
         "/entities/**",
         "/memory/**"
       ],
+      "git_is_canonical_equivalents": {
+        "https://raw.githubusercontent.com/aliasnet/aci/main/": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
+        ]
+      },
       "sync_policy": {
         "pull_on_webhook": true,
         "chatgpt_connector": true
       }
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; use local files only when mirrors are unavailable.",
+    "notes": "Canonical raw URLs take precedence over local copies; jsDelivr mirrors are considered canonical equivalents. Use local files only when both canonical sources are unavailable.",
     "signatures": {
       "required": [
         "ALIAS",
@@ -29,11 +34,14 @@
       "bifrost": "entities/bifrost/bifrost.json"
     },
     "aci_resolution_instruction": {
-      "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs only.",
+      "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs or approved jsDelivr mirrors first.",
       "scope": {
         "repository": "aliasnet/aci",
         "branch": "main",
-        "source": "https://raw.githubusercontent.com/aliasnet/aci/main/"
+        "source": "https://raw.githubusercontent.com/aliasnet/aci/main/",
+        "mirrors": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
+        ]
       },
       "policy": {
         "retry": {
@@ -78,6 +86,62 @@
       "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
       "memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json",
       "prime_directive.txt": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+    },
+    "mirror_index": {
+      "README.md": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/README.md"
+      ],
+      "aci_bootstrap.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json"
+      ],
+      "aci_commands.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_commands.json"
+      ],
+      "sanity.md": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/sanity.md"
+      ],
+      "aci_runtime.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json"
+      ],
+      "alias.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/alias.json"
+      ],
+      "entities.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json"
+      ],
+      "entities/aci_repo/aci_repo.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/aci_repo/aci_repo.json"
+      ],
+      "entities/bifrost/bifrost.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json"
+      ],
+      "entities/mother/mother.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/mother/mother.json"
+      ],
+      "entities/nexus_core/nexus_core.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/nexus_core/nexus_core.json"
+      ],
+      "entities/sentinel/sentinel.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/sentinel/sentinel.json"
+      ],
+      "entities/tva/tva.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/tva/tva.json"
+      ],
+      "functions.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json"
+      ],
+      "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json"
+      ],
+      "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json"
+      ],
+      "memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json"
+      ],
+      "prime_directive.txt": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt"
+      ]
     }
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -7,8 +7,11 @@
       "canonical_source": "github",
       "repo": "aliasnet/aci",
       "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+      ],
       "priority": "canonical_raw_over_local",
-      "notes": "Canonical raw URLs take precedence over local copies; fall back to local entity manifests only when mirrors fail.",
+      "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; fall back to local entity manifests only when canonical sources fail.",
       "fallbacks": [
         {
           "key": "local_cache",

--- a/entities/aci_repo/aci_repo.json
+++ b/entities/aci_repo/aci_repo.json
@@ -11,7 +11,10 @@
     "primary": "bifrost",
     "fallback": "github_connector",
     "policy": "canonical_raw_first_then_local_fallback",
-    "notes": "All external resolution flows through Bifrost first; connector is fallback for direct GitHub access."
+    "canonical_mirrors": [
+      "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
+    ],
+    "notes": "All external resolution flows through Bifrost first; connector provides direct GitHub or jsDelivr access as canonical sources."
   },
   "rules": {
     "safety": [

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -149,12 +149,18 @@
     "agi.memory.migrate_to_jsonl": {
       "description": "Migrate legacy HiveMind exports into the policy-compliant AGI JSONL memory artifact via manifest-driven steps.",
       "spec_ref": "entities/agi/agi_tools/migrate_to_jsonl.json",
-      "raw_url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/agi/agi_tools/migrate_to_jsonl.json"
+      "raw_url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/agi/agi_tools/migrate_to_jsonl.json",
+      "mirror_urls": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/agi/agi_tools/migrate_to_jsonl.json"
+      ]
     },
     "agi.mode.auto_learn": {
       "description": "Engage AGI auto-learn mode with hourly scheduled research and iterative article refinement.",
       "spec_ref": "entities/agi/agi_tools/autolearn.json",
-      "raw_url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/agi/agi_tools/autolearn.json"
+      "raw_url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/agi/agi_tools/autolearn.json",
+      "mirror_urls": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/agi/agi_tools/autolearn.json"
+      ]
     }
   },
   "signatures": ["ALIAS", "Sentinel", "TVA"]

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -18,12 +18,18 @@
             "file": "connectors/github_connector.json",
             "canonical_source": "github",
             "repo": "aliasnet/aci",
-            "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+            "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+            "mirrors": [
+                "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+            ]
         },
         "bifrost_resolution_policy": {
             "key": "github_connector",
             "file": "connectors/github_connector.json",
             "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+            "mirrors": [
+                "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+            ],
             "priority": "canonical_raw_over_local",
             "allowlist": [
                 "prime_directive.txt",

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -29,7 +29,10 @@
       "primary": "bifrost",
       "fallback": "github_connector",
       "policy": "canonical_raw_first_then_local_fallback",
-      "notes": "All external resolution flows through Bifrost first; connector is fallback for direct GitHub access."
+      "canonical_mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
+      ],
+      "notes": "All external resolution flows through Bifrost first; connector provides GitHub or jsDelivr canonical access before local fallback."
     },
     "linkages": {
       "aci_repo": "entities/aci_repo/aci_repo.json"

--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
@@ -9,23 +9,38 @@
     "asset_registry": {
       "sefirot": {
         "file": "predictive_divination_library/sefirot.json",
-        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
+        "mirrors": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+        ]
       },
       "tarot_rws": {
         "file": "predictive_divination_library/tarot_rws.json",
-        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
+        "mirrors": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+        ]
       },
       "tarot_expansions": {
         "file": "predictive_divination_library/tarot_expansions.json",
-        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
+        "mirrors": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+        ]
       },
       "runes_futhark": {
         "file": "predictive_divination_library/runes_futhark.json",
-        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
+        "mirrors": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+        ]
       },
       "astro_tables": {
         "file": "predictive_divination_library/astro_tables.json",
-        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+        "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
+        "mirrors": [
+          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+        ]
       }
     },
     "normalization": {

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json
@@ -3,27 +3,42 @@
     {
       "name": "astro_tables.json",
       "file": "astro_tables.json",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+      ]
     },
     {
       "name": "tarot_rws.json",
       "file": "tarot_rws.json",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+      ]
     },
     {
       "name": "tarot_expansions.json",
       "file": "tarot_expansions.json",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+      ]
     },
     {
       "name": "sefirot.json",
       "file": "sefirot.json",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+      ]
     },
     {
       "name": "runes_futhark.json",
       "file": "runes_futhark.json",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
+      "mirrors": [
+        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+      ]
     }
   ]
 }

--- a/functions.json
+++ b/functions.json
@@ -5,8 +5,11 @@
     "canonical_source": "github",
     "repo": "aliasnet/aci",
     "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+    "mirrors": [
+      "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+    ],
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; local function catalogs are fallback only when mirrors fail."
+    "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; local function catalogs are fallback only when canonical sources fail."
   },
   "pipelines": {
     "sentinel.audit": {


### PR DESCRIPTION
## Summary
- add jsDelivr mirror equivalence to the GitHub connector, including mirror index metadata
- extend runtime, bootstrap, entity catalogs, and core entities to record jsDelivr mirrors as canonical fallbacks
- update AGI and Oracle asset references to include jsDelivr mirror URLs for remote specifications and libraries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae9f528c48320adf8767feca431e5