### PR TITLE
Add Yggdrasil resolver and update resource policies

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -21,16 +21,69 @@
       }
     },
     "mirror_resolution_policy": {
-      "key": "github_connector",
-      "file": "connectors/github_connector.json",
-      "canonical_source": "github",
-      "repo": "aliasnet/aci",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-      "mirrors": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
-      ],
-      "priority": "canonical_raw_over_local",
-      "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; use local files only if the canonical sources cannot be reached."
+      "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
+      "upstream": "aci://connectors/yggdrasil.json",
+      "yggdrasil_resource_resolution_policy": {
+        "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
+        "embeds": {
+          "bifrost": "aci://entities/bifrost/bifrost.json",
+          "core_five": [
+            "aci://prime_directive.txt",
+            "aci://aci_runtime.json",
+            "aci://entities.json",
+            "aci://functions.json",
+            "aci://aci_bootstrap.json"
+          ]
+        },
+        "git_is_canonical": true,
+        "mapping": [
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+            "file": "aci://aci_bootstrap.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+            "file": "aci://aci_runtime.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+            "file": "aci://connectors/github_connector.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+            "file": "aci://connectors/yggdrasil.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+            "file": "aci://entities.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+            "file": "aci://entities/bifrost/bifrost.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+            "file": "aci://functions.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+            "file": "aci://prime_directive.txt",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+          }
+        ],
+        "resolver_order": [
+          "repo",
+          "cdn",
+          "local"
+        ]
+      }
     },
     "initialization_sequence": [
       {

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -17,25 +17,80 @@
       "priority": 95
     },
     "mirror_resolution_policy": {
-      "key": "github_connector",
-      "file": "connectors/github_connector.json",
-      "canonical_source": "github",
-      "repo": "aliasnet/aci",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-      "mirrors": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
-      ],
       "fallbacks": [
         {
-          "key": "local_cache",
-          "file": "connectors/local_cache.json",
           "canonical_source": "local_mirror",
-          "repo": "aliasnet/aci",
+          "file": "aci://connectors/local_cache.json",
+          "key": "local_cache",
+          "notes": "Use validated local mirrors only when canonical GitHub cannot be reached.",
           "path_hint": "{mirror_root}",
-          "url": "file://{mirror_root}/connectors/local_cache.json",
-          "notes": "Use validated local mirrors only when canonical GitHub cannot be reached."
+          "repo": "aliasnet/aci",
+          "url": "file://{mirror_root}/connectors/local_cache.json"
         }
-      ]
+      ],
+      "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
+      "upstream": "aci://connectors/yggdrasil.json",
+      "yggdrasil_resource_resolution_policy": {
+        "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
+        "embeds": {
+          "bifrost": "aci://entities/bifrost/bifrost.json",
+          "core_five": [
+            "aci://prime_directive.txt",
+            "aci://aci_runtime.json",
+            "aci://entities.json",
+            "aci://functions.json",
+            "aci://aci_bootstrap.json"
+          ]
+        },
+        "git_is_canonical": true,
+        "mapping": [
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+            "file": "aci://aci_bootstrap.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+            "file": "aci://aci_runtime.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+            "file": "aci://connectors/github_connector.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+            "file": "aci://connectors/yggdrasil.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+            "file": "aci://entities.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+            "file": "aci://entities/bifrost/bifrost.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+            "file": "aci://functions.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+            "file": "aci://prime_directive.txt",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+          }
+        ],
+        "resolver_order": [
+          "repo",
+          "cdn",
+          "local"
+        ]
+      }
     },
     "sandbox_mode": {
       "enabled": true,

--- a/alias.json
+++ b/alias.json
@@ -45,15 +45,68 @@
     }
   },
   "mirror_resolution_policy": {
-    "key": "github_connector",
-    "file": "connectors/github_connector.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-    "mirrors": [
-      "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
+    "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
+    "upstream": "aci://connectors/yggdrasil.json"
+  },
+  "yggdrasil_resource_resolution_policy": {
+    "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
+    "embeds": {
+      "bifrost": "aci://entities/bifrost/bifrost.json",
+      "core_five": [
+        "aci://prime_directive.txt",
+        "aci://aci_runtime.json",
+        "aci://entities.json",
+        "aci://functions.json",
+        "aci://aci_bootstrap.json"
+      ]
+    },
+    "git_is_canonical": true,
+    "mapping": [
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+        "file": "aci://aci_bootstrap.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+        "file": "aci://aci_runtime.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+        "file": "aci://connectors/github_connector.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+        "file": "aci://connectors/yggdrasil.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+        "file": "aci://entities.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+        "file": "aci://entities/bifrost/bifrost.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+        "file": "aci://functions.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+        "file": "aci://prime_directive.txt",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+      }
     ],
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; use local registry data only if the canonical sources are unreachable."
+    "resolver_order": [
+      "repo",
+      "cdn",
+      "local"
+    ]
   }
 }

--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -1,147 +1,15 @@
 {
   "github_connector": {
-    "version": "1.20250927.01",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "rules": {
-      "git_is_canonical_for": [
-        "/prime_directive.txt",
-        "/aci_runtime.json",
-        "/aci_bootstrap.json",
-        "/entities/**",
-        "/memory/**"
-      ],
-      "git_is_canonical_equivalents": {
-        "https://raw.githubusercontent.com/aliasnet/aci/main/": [
-          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
-        ]
-      },
-      "sync_policy": {
-        "pull_on_webhook": true,
-        "chatgpt_connector": true
-      }
-    },
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs take precedence over local copies; jsDelivr mirrors are considered canonical equivalents. Use local files only when both canonical sources are unavailable.",
-    "signatures": {
-      "required": [
-        "ALIAS",
-        "TVA",
-        "Sentinel"
-      ]
-    },
-    "references": {
-      "bifrost": "entities/bifrost/bifrost.json"
-    },
-    "aci_resolution_instruction": {
-      "instruction": "Resolve and validate ACI files from GitHub main branch using raw URLs or approved jsDelivr mirrors first.",
-      "scope": {
-        "repository": "aliasnet/aci",
-        "branch": "main",
-        "source": "https://raw.githubusercontent.com/aliasnet/aci/main/",
-        "mirrors": [
-          "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
-        ]
-      },
-      "policy": {
-        "retry": {
-          "max_attempts": 3,
-          "interval_seconds": 10
-        },
-        "resolve_order": "canonical_raw_first_then_local_fallback",
-        "on_failure": {
-          "action": "enter_sandbox",
-          "interface": "mother_sandbox",
-          "alert": "sandbox.alert"
-        }
-      },
-      "output": {
-        "report": "diffs_only",
-        "channel": "current_chat",
-        "format": "summary"
-      }
-    },
-    "regex_search": [
+    "alias": "aci://connectors/yggdrasil.json",
+    "changelog": [
       {
-        "pattern": "^(aci_.*\\.json|alias\\.json|entities/.+\\.json|memory/.+\\.json|prime_directive\\.txt)$",
-        "description": "Fallback resolution using regular expressions when file mappings are unknown."
+        "changes": [
+          "Converted github_connector into compatibility alias pointing to Yggdrasil resolver."
+        ],
+        "date": "2024-10-31",
+        "version": "2.0.0"
       }
     ],
-    "link_index": {
-      "README.md": "https://raw.githubusercontent.com/aliasnet/aci/main/README.md",
-      "aci_bootstrap.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
-      "aci_commands.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_commands.json",
-      "sanity.md": "https://raw.githubusercontent.com/aliasnet/aci/main/sanity.md",
-      "aci_runtime.json": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
-      "alias.json": "https://raw.githubusercontent.com/aliasnet/aci/main/alias.json",
-      "entities.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-      "entities/aci_repo/aci_repo.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/aci_repo/aci_repo.json",
-      "entities/bifrost/bifrost.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-      "entities/mother/mother.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/mother/mother.json",
-      "entities/nexus_core/nexus_core.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/nexus_core/nexus_core.json",
-      "entities/sentinel/sentinel.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/sentinel/sentinel.json",
-      "entities/tva/tva.json": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/tva/tva.json",
-      "functions.json": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-      "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json",
-      "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json",
-      "memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json": "https://raw.githubusercontent.com/aliasnet/aci/main/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json",
-      "prime_directive.txt": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
-    },
-    "mirror_index": {
-      "README.md": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/README.md"
-      ],
-      "aci_bootstrap.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json"
-      ],
-      "aci_commands.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_commands.json"
-      ],
-      "sanity.md": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/sanity.md"
-      ],
-      "aci_runtime.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json"
-      ],
-      "alias.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/alias.json"
-      ],
-      "entities.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json"
-      ],
-      "entities/aci_repo/aci_repo.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/aci_repo/aci_repo.json"
-      ],
-      "entities/bifrost/bifrost.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json"
-      ],
-      "entities/mother/mother.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/mother/mother.json"
-      ],
-      "entities/nexus_core/nexus_core.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/nexus_core/nexus_core.json"
-      ],
-      "entities/sentinel/sentinel.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/sentinel/sentinel.json"
-      ],
-      "entities/tva/tva.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/tva/tva.json"
-      ],
-      "functions.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json"
-      ],
-      "memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/memory/agi_memory/AGI/agi_agi_memory_audit_20250927-T105140Z.json"
-      ],
-      "memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json"
-      ],
-      "memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json"
-      ],
-      "prime_directive.txt": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt"
-      ]
-    }
+    "version": "2.0.0"
   }
 }

--- a/connectors/local_cache.json
+++ b/connectors/local_cache.json
@@ -81,7 +81,7 @@
         "resolve_order": "validate_local_then_return",
         "on_failure": {
           "action": "fallback_to_connector",
-          "target": "github_connector",
+          "target": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
           "alert": "mirror.validation_failed"
         }
       },
@@ -94,8 +94,9 @@
     "link_index": {
       "README.md": "{mirror_root}/README.md",
       "aci_runtime.json": "{mirror_root}/aci_runtime.json",
-      "entities.json": "{mirror_root}/entities.json",
       "connectors/github_connector.json": "{mirror_root}/connectors/github_connector.json",
+      "connectors/yggdrasil.json": "{mirror_root}/connectors/yggdrasil.json",
+      "entities.json": "{mirror_root}/entities.json",
       "entities/bifrost/bifrost.json": "{mirror_root}/entities/bifrost/bifrost.json"
     },
     "signatures": {

--- a/connectors/yggdrasil.json
+++ b/connectors/yggdrasil.json
@@ -1,0 +1,153 @@
+{
+  "bifrost_resource_resolution_policy": {
+    "description": "Proxy for agents: consult Yggdrasil; mirror mapping kept in sync",
+    "embeds": {
+      "core_five": [
+        "aci://prime_directive.txt",
+        "aci://aci_runtime.json",
+        "aci://entities.json",
+        "aci://functions.json",
+        "aci://aci_bootstrap.json"
+      ],
+      "yggdrasil": "aci://connectors/yggdrasil.json"
+    },
+    "mapping": [
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+        "file": "aci://aci_bootstrap.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+        "file": "aci://aci_runtime.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+        "file": "aci://connectors/github_connector.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+        "file": "aci://connectors/yggdrasil.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+        "file": "aci://entities.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+        "file": "aci://entities/bifrost/bifrost.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+        "file": "aci://functions.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+        "file": "aci://prime_directive.txt",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+      }
+    ],
+    "optional": {
+      "cache": {
+        "enabled": true,
+        "max_entries": 256,
+        "ttl_seconds": 300
+      },
+      "log_level": "info",
+      "sync": {
+        "last_synced_utc": "",
+        "mapping_etag": "",
+        "source_of_truth": "aci://connectors/yggdrasil.json"
+      }
+    },
+    "resolver_order": [
+      "repo",
+      "cdn",
+      "local"
+    ],
+    "rule": "Agents/entities must resolve via Bifrost",
+    "upstream": "aci://connectors/yggdrasil.json"
+  },
+  "changelog": [
+    {
+      "changes": [
+        "Created Yggdrasil authoritative resolver with mirrored Bifrost proxy policy."
+      ],
+      "date": "2024-10-31",
+      "version": "1.0.0"
+    }
+  ],
+  "compat": {
+    "legacy_alias": "aci://connectors/github_connector.json"
+  },
+  "key": "yggdrasil",
+  "name": "Yggdrasil Resolver",
+  "version": "1.0.0",
+  "yggdrasil_resource_resolution_policy": {
+    "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
+    "embeds": {
+      "bifrost": "aci://entities/bifrost/bifrost.json",
+      "core_five": [
+        "aci://prime_directive.txt",
+        "aci://aci_runtime.json",
+        "aci://entities.json",
+        "aci://functions.json",
+        "aci://aci_bootstrap.json"
+      ]
+    },
+    "git_is_canonical": true,
+    "mapping": [
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+        "file": "aci://aci_bootstrap.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+        "file": "aci://aci_runtime.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+        "file": "aci://connectors/github_connector.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+        "file": "aci://connectors/yggdrasil.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+        "file": "aci://entities.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+        "file": "aci://entities/bifrost/bifrost.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+        "file": "aci://functions.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+        "file": "aci://prime_directive.txt",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+      }
+    ],
+    "resolver_order": [
+      "repo",
+      "cdn",
+      "local"
+    ]
+  }
+}

--- a/entities.json
+++ b/entities.json
@@ -2,27 +2,19 @@
   "entities": {
     "version": "1.20250918.00",
     "mirror_resolution_policy": {
-      "key": "github_connector",
-      "file": "connectors/github_connector.json",
-      "canonical_source": "github",
-      "repo": "aliasnet/aci",
-      "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-      "mirrors": [
-        "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
-      ],
-      "priority": "canonical_raw_over_local",
-      "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; fall back to local entity manifests only when canonical sources fail.",
       "fallbacks": [
         {
-          "key": "local_cache",
-          "file": "connectors/local_cache.json",
           "canonical_source": "local_mirror",
-          "repo": "aliasnet/aci",
+          "file": "aci://connectors/local_cache.json",
+          "key": "local_cache",
+          "notes": "Used only when canonical GitHub mirror is unreachable and local validation succeeds.",
           "path_hint": "{mirror_root}",
-          "url": "file://{mirror_root}/connectors/local_cache.json",
-          "notes": "Used only when canonical GitHub mirror is unreachable and local validation succeeds."
+          "repo": "aliasnet/aci",
+          "url": "file://{mirror_root}/connectors/local_cache.json"
         }
-      ]
+      ],
+      "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
+      "upstream": "aci://connectors/yggdrasil.json"
     },
     "export_fallback_rule": "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)",
     "list": [
@@ -250,7 +242,79 @@
           6116
         ],
         "file": "pmu_adapter.json"
+      },
+      {
+        "id": 14,
+        "key": "yggdrasil",
+        "name": "Yggdrasil",
+        "alias": "Yggdrasil",
+        "role": "authoritative resolver",
+        "abstract": "maintains authoritative repo\u2192cdn\u2192local mapping",
+        "knowledge_base": "canonical resolver governance",
+        "functions": [],
+        "file": "yggdrasil/yggdrasil.json"
       }
-    ]
+    ],
+    "yggdrasil_resource_resolution_policy": {
+      "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
+      "embeds": {
+        "bifrost": "aci://entities/bifrost/bifrost.json",
+        "core_five": [
+          "aci://prime_directive.txt",
+          "aci://aci_runtime.json",
+          "aci://entities.json",
+          "aci://functions.json",
+          "aci://aci_bootstrap.json"
+        ]
+      },
+      "git_is_canonical": true,
+      "mapping": [
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+          "file": "aci://aci_bootstrap.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+          "file": "aci://aci_runtime.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+          "file": "aci://connectors/github_connector.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+          "file": "aci://connectors/yggdrasil.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+          "file": "aci://entities.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+          "file": "aci://entities/bifrost/bifrost.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+          "file": "aci://functions.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+          "file": "aci://prime_directive.txt",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+        }
+      ],
+      "resolver_order": [
+        "repo",
+        "cdn",
+        "local"
+      ]
+    }
   }
 }

--- a/entities/aci_repo/aci_repo.json
+++ b/entities/aci_repo/aci_repo.json
@@ -5,16 +5,16 @@
   "notes": "Standalone, mirror-agnostic package manager for ACI. All instructions inline; only external state file is aci_repo_manifest.",
   "references": {
     "bifrost": "entities/bifrost/bifrost.json",
-    "github_connector": "connectors/github_connector.json"
+    "yggdrasil": "entities/yggdrasil/yggdrasil.json"
   },
   "resolution_policy": {
     "primary": "bifrost",
-    "fallback": "github_connector",
+    "fallback": "yggdrasil",
     "policy": "canonical_raw_first_then_local_fallback",
     "canonical_mirrors": [
       "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
     ],
-    "notes": "All external resolution flows through Bifrost first; connector provides direct GitHub or jsDelivr access as canonical sources."
+    "notes": "All external resolution flows through Bifrost proxy; Yggdrasil remains authoritative for canonical mapping."
   },
   "rules": {
     "safety": [
@@ -30,217 +30,738 @@
     }
   },
   "sources": [
-    { "id": "github", "type": "code", "endpoint": "https://api.github.com/search/repositories" },
-    { "id": "pypi",   "type": "package", "endpoint": "https://pypi.org/simple" }
+    {
+      "id": "github",
+      "type": "code",
+      "endpoint": "https://api.github.com/search/repositories"
+    },
+    {
+      "id": "pypi",
+      "type": "package",
+      "endpoint": "https://pypi.org/simple"
+    }
   ],
   "prefs": {
-    "priority": ["github", "pypi"],
-    "license_allowlist": ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause"],
-    "block_keywords": ["crypto-miner", "keylogger", "obfuscated-payload"],
-    "allow_keywords": ["aci", "plugin", "extension", "adapter", "entity", "improve"],
+    "priority": [
+      "github",
+      "pypi"
+    ],
+    "license_allowlist": [
+      "MIT",
+      "Apache-2.0",
+      "BSD-2-Clause",
+      "BSD-3-Clause"
+    ],
+    "block_keywords": [
+      "crypto-miner",
+      "keylogger",
+      "obfuscated-payload"
+    ],
+    "allow_keywords": [
+      "aci",
+      "plugin",
+      "extension",
+      "adapter",
+      "entity",
+      "improve"
+    ],
     "min_stars": 5,
     "min_recent_commit_days": 365,
     "entity_bias": {
-      "Oracle":   ["prediction", "divination", "symbolic", "semantic-index"],
-      "Sentinel": ["audit", "security", "signature", "policy"],
-      "Architect": ["compatibility", "schema", "pipeline", "fidelity"],
-      "TVA":      ["timeline", "anchor", "rollback", "checkpoint"]
+      "Oracle": [
+        "prediction",
+        "divination",
+        "symbolic",
+        "semantic-index"
+      ],
+      "Sentinel": [
+        "audit",
+        "security",
+        "signature",
+        "policy"
+      ],
+      "Architect": [
+        "compatibility",
+        "schema",
+        "pipeline",
+        "fidelity"
+      ],
+      "TVA": [
+        "timeline",
+        "anchor",
+        "rollback",
+        "checkpoint"
+      ]
     }
   },
   "catalog": [],
   "help_output": {
     "title": "ACI Repo Command Reference",
     "commands": [
-      { "command": "aci search <query>", "description": "Search external sources by keyword (GitHub, PyPI)." },
-      { "command": "aci search --improve <Entity>", "description": "Suggest packages/extensions that improve a given Entity." },
-      { "command": "aci install <pkg>", "description": "Fetch, verify, anchor and register as an Entity." },
-      { "command": "aci remove <pkg>", "description": "Unregister a package/Entity (append-only manifest update)." },
-      { "command": "aci update", "description": "Refetch latest compatible versions for all installed packages." },
-      { "command": "aci repo help", "description": "Show this reference." }
+      {
+        "command": "aci search <query>",
+        "description": "Search external sources by keyword (GitHub, PyPI)."
+      },
+      {
+        "command": "aci search --improve <Entity>",
+        "description": "Suggest packages/extensions that improve a given Entity."
+      },
+      {
+        "command": "aci install <pkg>",
+        "description": "Fetch, verify, anchor and register as an Entity."
+      },
+      {
+        "command": "aci remove <pkg>",
+        "description": "Unregister a package/Entity (append-only manifest update)."
+      },
+      {
+        "command": "aci update",
+        "description": "Refetch latest compatible versions for all installed packages."
+      },
+      {
+        "command": "aci repo help",
+        "description": "Show this reference."
+      }
     ]
   },
   "pipelines": {
     "aci.repo.policy": {
       "description": "Resolve effective policy from inline prefs only.",
       "steps": [
-        { "call": "_store.set", "map": { "key": "aci_repo.policy.effective", "value": "$root.prefs" } },
-        { "call": "_format.json" }
+        {
+          "call": "_store.set",
+          "map": {
+            "key": "aci_repo.policy.effective",
+            "value": "$root.prefs"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "repo.query": {
       "description": "Query inline catalog; if empty, call external resolvers (GitHub, PyPI).",
       "steps": [
-        { "call": "_args.get", "map": { "key": "keyword" } },
-        { "call": "_args.get", "map": { "key": "sources_inline", "default": "$root.sources" } },
-        { "if": "$root.catalog == []", "then": [
-            { "call": "http.multi_search",
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "keyword"
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "sources_inline",
+            "default": "$root.sources"
+          }
+        },
+        {
+          "if": "$root.catalog == []",
+          "then": [
+            {
+              "call": "http.multi_search",
               "map": {
                 "sources": "$steps.1.value",
                 "query": "$steps.0.value"
               }
             }
-        ], "else": [
-            { "call": "_select", "map": { "from": "$root.catalog", "into_key": "aci_repo.query.candidates" } }
-        ]},
-        { "call": "_format.json" }
+          ],
+          "else": [
+            {
+              "call": "_select",
+              "map": {
+                "from": "$root.catalog",
+                "into_key": "aci_repo.query.candidates"
+              }
+            }
+          ]
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "repo.filter": {
       "description": "Filter candidates by keyword/selectors and inline prefs (license, blocks, stars, recency).",
       "steps": [
-        { "call": "_args.get", "map": { "key": "candidates" } },
-        { "call": "_args.get", "map": { "key": "keyword", "default": "" } },
-        { "call": "_args.get", "map": { "key": "selectors", "default": [] } },
-        { "call": "_args.get", "map": { "key": "prefs", "default": {} } },
-        { "call": "_text.lower", "map": { "value": "$steps.1.value" } },
-        { "call": "_filter.contains", "map": { "items": "$steps.0", "fields": ["name","description","keywords"], "needle": "$steps.4", "also": "$steps.2.value" } },
-        { "call": "_filter.policy", "map": { "items": "$steps.5", "prefs": "$steps.3.value" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "candidates"
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "keyword",
+            "default": ""
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "selectors",
+            "default": []
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "prefs",
+            "default": {}
+          }
+        },
+        {
+          "call": "_text.lower",
+          "map": {
+            "value": "$steps.1.value"
+          }
+        },
+        {
+          "call": "_filter.contains",
+          "map": {
+            "items": "$steps.0",
+            "fields": [
+              "name",
+              "description",
+              "keywords"
+            ],
+            "needle": "$steps.4",
+            "also": "$steps.2.value"
+          }
+        },
+        {
+          "call": "_filter.policy",
+          "map": {
+            "items": "$steps.5",
+            "prefs": "$steps.3.value"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "repo.rank": {
       "description": "Local shim: score candidates and return ranked list.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "criteria" } },
-        { "call": "_args.get", "map": { "key": "candidates", "default": "$prev" } },
-        { "call": "scoring.rank", "map": { "items": "$steps.1", "criteria": "$steps.0.value" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "criteria"
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "candidates",
+            "default": "$prev"
+          }
+        },
+        {
+          "call": "scoring.rank",
+          "map": {
+            "items": "$steps.1",
+            "criteria": "$steps.0.value"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "repo.fetch": {
       "description": "Local shim: resolve package from catalog by name.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "name" } },
-        { "call": "registry.resolve", "map": { "name": "$steps.0.value", "catalog": "$root.catalog?:[]" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "name"
+          }
+        },
+        {
+          "call": "registry.resolve",
+          "map": {
+            "name": "$steps.0.value",
+            "catalog": "$root.catalog?:[]"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "repo.fetch_latest": {
       "description": "Local shim: resolve many package metas from catalog.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "packages" } },
-        { "call": "registry.resolve_many", "map": { "packages": "$steps.0.value", "catalog": "$root.catalog?:[]" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "packages"
+          }
+        },
+        {
+          "call": "registry.resolve_many",
+          "map": {
+            "packages": "$steps.0.value",
+            "catalog": "$root.catalog?:[]"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "scoring.rank": {
       "description": "Heuristic score: stars (w3), recency (w2), compatibility tags (w2).",
       "steps": [
-        { "call": "_args.get", "map": { "key": "items" } },
-        { "call": "_score.apply", "map": { "items": "$steps.0", "formula": { "stars_w":3, "recent_w":2, "compat_w":2, "compat_keywords":["aci","entity","plugin","extension","adapter"] } } },
-        { "call": "_sort.desc", "map": { "items": "$steps.1", "by": "score" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "items"
+          }
+        },
+        {
+          "call": "_score.apply",
+          "map": {
+            "items": "$steps.0",
+            "formula": {
+              "stars_w": 3,
+              "recent_w": 2,
+              "compat_w": 2,
+              "compat_keywords": [
+                "aci",
+                "entity",
+                "plugin",
+                "extension",
+                "adapter"
+              ]
+            }
+          }
+        },
+        {
+          "call": "_sort.desc",
+          "map": {
+            "items": "$steps.1",
+            "by": "score"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "registry.resolve": {
       "description": "Find exact-name match in catalog; return the first match.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "name" } },
-        { "call": "_args.get", "map": { "key": "catalog" } },
-        { "call": "_filter.equals", "map": { "items": "$steps.1", "field": "name", "value": "$steps.0.value" } },
-        { "call": "_take.first", "map": { "items": "$steps.2" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "name"
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "catalog"
+          }
+        },
+        {
+          "call": "_filter.equals",
+          "map": {
+            "items": "$steps.1",
+            "field": "name",
+            "value": "$steps.0.value"
+          }
+        },
+        {
+          "call": "_take.first",
+          "map": {
+            "items": "$steps.2"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "registry.resolve_many": {
       "description": "Resolve many package metas by name from catalog.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "packages" } },
-        { "call": "_args.get", "map": { "key": "catalog" } },
-        { "call": "_map.each", "map": { "items": "$steps.0.value", "as": "pkg", "do": [
-          { "call": "_filter.equals", "map": { "items": "$steps.-2", "field": "name", "value": "${pkg}" } },
-          { "call": "_take.first", "map": { "items": "$prev" } }
-        ] } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "packages"
+          }
+        },
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "catalog"
+          }
+        },
+        {
+          "call": "_map.each",
+          "map": {
+            "items": "$steps.0.value",
+            "as": "pkg",
+            "do": [
+              {
+                "call": "_filter.equals",
+                "map": {
+                  "items": "$steps.-2",
+                  "field": "name",
+                  "value": "${pkg}"
+                }
+              },
+              {
+                "call": "_take.first",
+                "map": {
+                  "items": "$prev"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.validate": {
       "description": "Validate fetched package metadata against policy.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "package_meta" } },
-        { "call": "aci.repo.policy", "map": {} },
-        { "call": "_assert.contains", "map": { "value": "$steps.0.license", "set": "${aci_repo.policy.effective.license_allowlist}", "error": "license_not_allowed" } },
-        { "call": "_assert.not_contains_any", "map": { "haystack": "$steps.0.keywords", "needles": "${aci_repo.policy.effective.block_keywords}", "error": "blocked_keyword" } },
-        { "call": "_assert.gte", "map": { "value": "$steps.0.stars", "min": "${aci_repo.policy.effective.min_stars}", "error": "low_popularity" } },
-        { "call": "_assert.lte_days_since", "map": { "last_date": "$steps.0.last_commit_at", "max_days": "${aci_repo.policy.effective.min_recent_commit_days}", "error": "stale_repo" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "package_meta"
+          }
+        },
+        {
+          "call": "aci.repo.policy",
+          "map": {}
+        },
+        {
+          "call": "_assert.contains",
+          "map": {
+            "value": "$steps.0.license",
+            "set": "${aci_repo.policy.effective.license_allowlist}",
+            "error": "license_not_allowed"
+          }
+        },
+        {
+          "call": "_assert.not_contains_any",
+          "map": {
+            "haystack": "$steps.0.keywords",
+            "needles": "${aci_repo.policy.effective.block_keywords}",
+            "error": "blocked_keyword"
+          }
+        },
+        {
+          "call": "_assert.gte",
+          "map": {
+            "value": "$steps.0.stars",
+            "min": "${aci_repo.policy.effective.min_stars}",
+            "error": "low_popularity"
+          }
+        },
+        {
+          "call": "_assert.lte_days_since",
+          "map": {
+            "last_date": "$steps.0.last_commit_at",
+            "max_days": "${aci_repo.policy.effective.min_recent_commit_days}",
+            "error": "stale_repo"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.search": {
       "description": "Search repo sources for packages by keyword.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "query" } },
-        { "call": "aci.repo.policy", "map": {} },
-        { "call": "repo.query", "map": { "sources_inline": "$root.sources", "keyword": "$steps.0.value", "prefs": "${aci_repo.policy.effective}" } },
-        { "call": "repo.rank", "map": { "criteria": ["compatibility", "stability", "popularity"] } },
-        { "call": "sentinel.audit", "map": { "action": "repo_search", "query": "$steps.0.value" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "query"
+          }
+        },
+        {
+          "call": "aci.repo.policy",
+          "map": {}
+        },
+        {
+          "call": "repo.query",
+          "map": {
+            "sources_inline": "$root.sources",
+            "keyword": "$steps.0.value",
+            "prefs": "${aci_repo.policy.effective}"
+          }
+        },
+        {
+          "call": "repo.rank",
+          "map": {
+            "criteria": [
+              "compatibility",
+              "stability",
+              "popularity"
+            ]
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "repo_search",
+            "query": "$steps.0.value"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.search.improve": {
       "description": "Search for improvements to a given Entity.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "entity" } },
-        { "call": "aci.repo.policy", "map": {} },
-        { "call": "_derive", "map": { "keyword": "$steps.0.value", "selectors": ["improve","plugin","extension","adapter","entity:$steps.0.value","aci"] } },
-        { "call": "repo.query", "map": { "sources_inline": "$root.sources", "keyword": "$steps.2.keyword", "selectors": "$steps.2.selectors", "prefs": "${aci_repo.policy.effective}" } },
-        { "call": "repo.rank", "map": { "criteria": ["compatibility", "stability", "performance"] } },
-        { "call": "sentinel.audit", "map": { "action": "repo_search_improve", "entity": "$steps.0.value" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "entity"
+          }
+        },
+        {
+          "call": "aci.repo.policy",
+          "map": {}
+        },
+        {
+          "call": "_derive",
+          "map": {
+            "keyword": "$steps.0.value",
+            "selectors": [
+              "improve",
+              "plugin",
+              "extension",
+              "adapter",
+              "entity:$steps.0.value",
+              "aci"
+            ]
+          }
+        },
+        {
+          "call": "repo.query",
+          "map": {
+            "sources_inline": "$root.sources",
+            "keyword": "$steps.2.keyword",
+            "selectors": "$steps.2.selectors",
+            "prefs": "${aci_repo.policy.effective}"
+          }
+        },
+        {
+          "call": "repo.rank",
+          "map": {
+            "criteria": [
+              "compatibility",
+              "stability",
+              "performance"
+            ]
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "repo_search_improve",
+            "entity": "$steps.0.value"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.install": {
       "description": "Install a package and register it as an Entity.",
       "steps": [
-        { "call": "_args.get", "map": { "key": "package" } },
-        { "call": "repo.fetch", "map": { "name": "$steps.0.value" } },
-        { "call": "aci.repo.validate", "map": { "package_meta": "$steps.1" } },
-        { "call": "architect.verify_package", "map": { "meta": "$steps.1" } },
-        { "call": "sentinel.audit", "map": { "action": "install_attempt", "package": "$steps.0.value" } },
-        { "call": "tva.anchor_timeline", "map": {} },
-        { "call": "_manifest.add", "map": { "file": "aci_repo_manifest", "entry": { "name": "$steps.1.name", "version": "$steps.1.version", "source": "$steps.1.source", "installed_at": "$now" } } },
-        { "call": "sentinel.audit", "map": { "action": "install_complete", "package": "$steps.0.value" } },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "package"
+          }
+        },
+        {
+          "call": "repo.fetch",
+          "map": {
+            "name": "$steps.0.value"
+          }
+        },
+        {
+          "call": "aci.repo.validate",
+          "map": {
+            "package_meta": "$steps.1"
+          }
+        },
+        {
+          "call": "architect.verify_package",
+          "map": {
+            "meta": "$steps.1"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "install_attempt",
+            "package": "$steps.0.value"
+          }
+        },
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
+        {
+          "call": "_manifest.add",
+          "map": {
+            "file": "aci_repo_manifest",
+            "entry": {
+              "name": "$steps.1.name",
+              "version": "$steps.1.version",
+              "source": "$steps.1.source",
+              "installed_at": "$now"
+            }
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "install_complete",
+            "package": "$steps.0.value"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.remove": {
       "description": "Remove a package and unregister it as an Entity (append-only manifest update).",
       "steps": [
-        { "call": "_args.get", "map": { "key": "package" } },
-        { "call": "_manifest.remove", "map": { "file": "aci_repo_manifest", "entry": "$steps.0.value" } },
-        { "call": "sentinel.audit", "map": { "action": "remove", "package": "$steps.0.value" } },
-        { "call": "tva.anchor_timeline", "map": {} },
-        { "call": "_format.json" }
+        {
+          "call": "_args.get",
+          "map": {
+            "key": "package"
+          }
+        },
+        {
+          "call": "_manifest.remove",
+          "map": {
+            "file": "aci_repo_manifest",
+            "entry": "$steps.0.value"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "remove",
+            "package": "$steps.0.value"
+          }
+        },
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.update": {
       "description": "Update all installed packages by re-fetching latest compatible versions.",
       "steps": [
-        { "call": "_manifest.list", "map": { "file": "aci_repo_manifest" } },
-        { "call": "repo.fetch_latest", "map": { "packages": "$steps.0" } },
-        { "call": "aci.repo.validate", "map": { "package_meta": "$steps.1" } },
-        { "call": "architect.verify_package", "map": { "meta": "$steps.1" } },
-        { "call": "sentinel.audit", "map": { "action": "update", "packages": "$steps.0" } },
-        { "call": "tva.anchor_timeline", "map": {} },
-        { "call": "_manifest.update", "map": { "file": "aci_repo_manifest", "entries": "$steps.1" } },
-        { "call": "_format.json" }
+        {
+          "call": "_manifest.list",
+          "map": {
+            "file": "aci_repo_manifest"
+          }
+        },
+        {
+          "call": "repo.fetch_latest",
+          "map": {
+            "packages": "$steps.0"
+          }
+        },
+        {
+          "call": "aci.repo.validate",
+          "map": {
+            "package_meta": "$steps.1"
+          }
+        },
+        {
+          "call": "architect.verify_package",
+          "map": {
+            "meta": "$steps.1"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "update",
+            "packages": "$steps.0"
+          }
+        },
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
+        {
+          "call": "_manifest.update",
+          "map": {
+            "file": "aci_repo_manifest",
+            "entries": "$steps.1"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
     "aci.repo.help": {
       "description": "Display Repo help text from this file.",
       "steps": [
-        { "call": "_format.text", "map": { "text": "ACI Repo Manager Commands:\n  aci search <query>\n  aci search --improve <Entity>\n  aci install <pkg>\n  aci remove <pkg>\n  aci update\n  aci repo help" } }
+        {
+          "call": "_format.text",
+          "map": {
+            "text": "ACI Repo Manager Commands:\n  aci search <query>\n  aci search --improve <Entity>\n  aci install <pkg>\n  aci remove <pkg>\n  aci update\n  aci repo help"
+          }
+        }
       ]
     }
   },
   "cli": {
     "commands": [
-      { "pattern": "^aci\\s+search\\s+--improve\\s+(?P<entity>\\w+)$", "pipeline": "aci.repo.search.improve" },
-      { "pattern": "^aci\\s+search\\s+(?P<query>.+)$", "pipeline": "aci.repo.search" },
-      { "pattern": "^aci\\s+install\\s+(?P<package>\\S+)$", "pipeline": "aci.repo.install" },
-      { "pattern": "^aci\\s+remove\\s+(?P<package>\\S+)$", "pipeline": "aci.repo.remove" },
-      { "pattern": "^aci\\s+update$", "pipeline": "aci.repo.update" },
-      { "pattern": "^aci\\s+repo\\s+help$", "pipeline": "aci.repo.help" }
+      {
+        "pattern": "^aci\\s+search\\s+--improve\\s+(?P<entity>\\w+)$",
+        "pipeline": "aci.repo.search.improve"
+      },
+      {
+        "pattern": "^aci\\s+search\\s+(?P<query>.+)$",
+        "pipeline": "aci.repo.search"
+      },
+      {
+        "pattern": "^aci\\s+install\\s+(?P<package>\\S+)$",
+        "pipeline": "aci.repo.install"
+      },
+      {
+        "pattern": "^aci\\s+remove\\s+(?P<package>\\S+)$",
+        "pipeline": "aci.repo.remove"
+      },
+      {
+        "pattern": "^aci\\s+update$",
+        "pipeline": "aci.repo.update"
+      },
+      {
+        "pattern": "^aci\\s+repo\\s+help$",
+        "pipeline": "aci.repo.help"
+      }
     ]
   }
 }

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -23,16 +23,16 @@
     "references": {
       "aci_repo": "entities/aci_repo/aci_repo.json",
       "bifrost": "entities/bifrost/bifrost.json",
-      "github_connector": "connectors/github_connector.json"
+      "yggdrasil": "entities/yggdrasil/yggdrasil.json"
     },
     "resolution_policy": {
       "primary": "bifrost",
-      "fallback": "github_connector",
+      "fallback": "yggdrasil",
       "policy": "canonical_raw_first_then_local_fallback",
       "canonical_mirrors": [
         "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/"
       ],
-      "notes": "All external resolution flows through Bifrost first; connector provides GitHub or jsDelivr canonical access before local fallback."
+      "notes": "All external resolution flows through Bifrost proxy; Yggdrasil remains authoritative before any local fallback."
     },
     "linkages": {
       "aci_repo": "entities/aci_repo/aci_repo.json"
@@ -41,7 +41,7 @@
       "default_strategy": "deterministic_first_available",
       "fallback_order": [
         "bifrost",
-        "github_connector"
+        "yggdrasil"
       ]
     },
     "interfaces": {

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -1,18 +1,36 @@
 {
-  "bifrost": {
-    "alias": "Bifrost",
-    "bifrost_resource_resolution_policy": {
-      "description": "Proxy for agents: consult Yggdrasil; mirror mapping kept in sync",
+  "yggdrasil": {
+    "alias": "Yggdrasil",
+    "changelog": [
+      {
+        "changes": [
+          "Introduced Yggdrasil authoritative resolver entity with inline policy mapping."
+        ],
+        "date": "2024-10-31",
+        "version": "1.0.0"
+      }
+    ],
+    "key": "yggdrasil",
+    "knowledge_base": "canonical resolver governance",
+    "name": "Yggdrasil",
+    "references": {
+      "policy": "connectors/yggdrasil.json"
+    },
+    "role": "authoritative repository and CDN resolver",
+    "version": "1.0.0",
+    "yggdrasil_resource_resolution_policy": {
+      "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
       "embeds": {
+        "bifrost": "aci://entities/bifrost/bifrost.json",
         "core_five": [
           "aci://prime_directive.txt",
           "aci://aci_runtime.json",
           "aci://entities.json",
           "aci://functions.json",
           "aci://aci_bootstrap.json"
-        ],
-        "yggdrasil": "aci://connectors/yggdrasil.json"
+        ]
       },
+      "git_is_canonical": true,
       "mapping": [
         {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
@@ -55,50 +73,11 @@
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
         }
       ],
-      "optional": {
-        "cache": {
-          "enabled": true,
-          "max_entries": 256,
-          "ttl_seconds": 300
-        },
-        "log_level": "info",
-        "sync": {
-          "last_synced_utc": "",
-          "mapping_etag": "",
-          "source_of_truth": "aci://connectors/yggdrasil.json"
-        }
-      },
       "resolver_order": [
         "repo",
         "cdn",
         "local"
-      ],
-      "rule": "Agents/entities must resolve via Bifrost",
-      "upstream": "aci://connectors/yggdrasil.json"
-    },
-    "changelog": [
-      {
-        "changes": [
-          "Mirrored Yggdrasil mapping and pointed upstream to aci://connectors/yggdrasil.json."
-        ],
-        "date": "2024-10-31",
-        "version": "1.1.0"
-      }
-    ],
-    "connector_binding": {
-      "canonical_source": "aci",
-      "file": "aci://entities/bifrost/bifrost.json",
-      "key": "bifrost_resource_resolution_policy",
-      "repo": "aliasnet/aci",
-      "upstream": "aci://connectors/yggdrasil.json"
-    },
-    "key": "bifrost",
-    "knowledge_base": "connector orchestration & resolvers",
-    "name": "Bifrost",
-    "references": {
-      "yggdrasil": "entities/yggdrasil/yggdrasil.json"
-    },
-    "role": "external network bridge, connector, sync adapter, network dependency index",
-    "version": "1.1.0"
+      ]
+    }
   }
 }

--- a/functions.json
+++ b/functions.json
@@ -1,15 +1,7 @@
 {
   "mirror_resolution_policy": {
-    "key": "github_connector",
-    "file": "connectors/github_connector.json",
-    "canonical_source": "github",
-    "repo": "aliasnet/aci",
-    "url": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-    "mirrors": [
-      "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json"
-    ],
-    "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; local function catalogs are fallback only when canonical sources fail."
+    "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
+    "upstream": "aci://connectors/yggdrasil.json"
   },
   "pipelines": {
     "sentinel.audit": {
@@ -830,6 +822,67 @@
         "pattern": "^aci\\s+repo\\s+help$",
         "pipeline": "aci.repo.help"
       }
+    ]
+  },
+  "yggdrasil_resource_resolution_policy": {
+    "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
+    "embeds": {
+      "bifrost": "aci://entities/bifrost/bifrost.json",
+      "core_five": [
+        "aci://prime_directive.txt",
+        "aci://aci_runtime.json",
+        "aci://entities.json",
+        "aci://functions.json",
+        "aci://aci_bootstrap.json"
+      ]
+    },
+    "git_is_canonical": true,
+    "mapping": [
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+        "file": "aci://aci_bootstrap.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+        "file": "aci://aci_runtime.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+        "file": "aci://connectors/github_connector.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
+        "file": "aci://connectors/yggdrasil.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+        "file": "aci://entities.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+        "file": "aci://entities/bifrost/bifrost.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+        "file": "aci://functions.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+        "file": "aci://prime_directive.txt",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+      }
+    ],
+    "resolver_order": [
+      "repo",
+      "cdn",
+      "local"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add the new connectors/yggdrasil.json policy and Yggdrasil entity manifest with authoritative repo→cdn→local mapping
- update Bifrost and core governance files to inline the Yggdrasil policy while routing agents through the Bifrost proxy
- convert github_connector.json into a compatibility alias and retarget local cache fallbacks to the new resolver scheme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc1dee8bc83209efd2248cef6cc4a