### PR TITLE
Refactor Yggdrasil resolver policies into entity manifest

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -21,8 +21,8 @@
       }
     },
     "mirror_resolution_policy": {
-      "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
-      "upstream": "aci://connectors/yggdrasil.json",
+      "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json",
       "yggdrasil_resource_resolution_policy": {
         "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
         "embeds": {
@@ -53,11 +53,6 @@
             "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
           },
           {
-            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-            "file": "aci://connectors/yggdrasil.json",
-            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-          },
-          {
             "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
             "file": "aci://entities.json",
             "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -66,6 +61,11 @@
             "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
             "file": "aci://entities/bifrost/bifrost.json",
             "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+            "file": "aci://entities/yggdrasil/yggdrasil.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
           },
           {
             "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -28,8 +28,8 @@
           "url": "file://{mirror_root}/connectors/local_cache.json"
         }
       ],
-      "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
-      "upstream": "aci://connectors/yggdrasil.json",
+      "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json",
       "yggdrasil_resource_resolution_policy": {
         "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
         "embeds": {
@@ -60,11 +60,6 @@
             "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
           },
           {
-            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-            "file": "aci://connectors/yggdrasil.json",
-            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-          },
-          {
             "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
             "file": "aci://entities.json",
             "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -73,6 +68,11 @@
             "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
             "file": "aci://entities/bifrost/bifrost.json",
             "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+          },
+          {
+            "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+            "file": "aci://entities/yggdrasil/yggdrasil.json",
+            "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
           },
           {
             "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",

--- a/alias.json
+++ b/alias.json
@@ -45,8 +45,8 @@
     }
   },
   "mirror_resolution_policy": {
-    "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
-    "upstream": "aci://connectors/yggdrasil.json"
+    "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
+    "upstream": "aci://entities/yggdrasil/yggdrasil.json"
   },
   "yggdrasil_resource_resolution_policy": {
     "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
@@ -78,11 +78,6 @@
         "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
       },
       {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-        "file": "aci://connectors/yggdrasil.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-      },
-      {
         "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
         "file": "aci://entities.json",
         "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -91,6 +86,11 @@
         "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
         "file": "aci://entities/bifrost/bifrost.json",
         "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+        "file": "aci://entities/yggdrasil/yggdrasil.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
       },
       {
         "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",

--- a/connectors/github_connector.json
+++ b/connectors/github_connector.json
@@ -1,15 +1,15 @@
 {
   "github_connector": {
-    "alias": "aci://connectors/yggdrasil.json",
+    "alias": "aci://entities/yggdrasil/yggdrasil.json",
     "changelog": [
       {
         "changes": [
-          "Converted github_connector into compatibility alias pointing to Yggdrasil resolver."
+          "Retargeted compatibility alias to entities/yggdrasil/yggdrasil.json."
         ],
-        "date": "2024-10-31",
-        "version": "2.0.0"
+        "date": "2024-11-05",
+        "version": "2.1.0"
       }
     ],
-    "version": "2.0.0"
+    "version": "2.1.0"
   }
 }

--- a/connectors/local_cache.json
+++ b/connectors/local_cache.json
@@ -95,7 +95,7 @@
       "README.md": "{mirror_root}/README.md",
       "aci_runtime.json": "{mirror_root}/aci_runtime.json",
       "connectors/github_connector.json": "{mirror_root}/connectors/github_connector.json",
-      "connectors/yggdrasil.json": "{mirror_root}/connectors/yggdrasil.json",
+      "entities/yggdrasil/yggdrasil.json": "{mirror_root}/entities/yggdrasil/yggdrasil.json",
       "entities.json": "{mirror_root}/entities.json",
       "entities/bifrost/bifrost.json": "{mirror_root}/entities/bifrost/bifrost.json"
     },

--- a/connectors/yggdrasil.json
+++ b/connectors/yggdrasil.json
@@ -1,153 +1,18 @@
 {
-  "bifrost_resource_resolution_policy": {
-    "description": "Proxy for agents: consult Yggdrasil; mirror mapping kept in sync",
-    "embeds": {
-      "core_five": [
-        "aci://prime_directive.txt",
-        "aci://aci_runtime.json",
-        "aci://entities.json",
-        "aci://functions.json",
-        "aci://aci_bootstrap.json"
-      ],
-      "yggdrasil": "aci://connectors/yggdrasil.json"
-    },
-    "mapping": [
+  "yggdrasil": {
+    "alias": "aci://entities/yggdrasil/yggdrasil.json",
+    "changelog": [
       {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
-        "file": "aci://aci_bootstrap.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
-        "file": "aci://aci_runtime.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
-        "file": "aci://connectors/github_connector.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-        "file": "aci://connectors/yggdrasil.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
-        "file": "aci://entities.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
-        "file": "aci://entities/bifrost/bifrost.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
-        "file": "aci://functions.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
-        "file": "aci://prime_directive.txt",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+        "changes": [
+          "Moved resolver policies to entities/yggdrasil/yggdrasil.json and converted connector to alias."
+        ],
+        "date": "2024-11-05",
+        "version": "1.1.0"
       }
     ],
-    "optional": {
-      "cache": {
-        "enabled": true,
-        "max_entries": 256,
-        "ttl_seconds": 300
-      },
-      "log_level": "info",
-      "sync": {
-        "last_synced_utc": "",
-        "mapping_etag": "",
-        "source_of_truth": "aci://connectors/yggdrasil.json"
-      }
+    "compat": {
+      "legacy_alias": "aci://connectors/github_connector.json"
     },
-    "resolver_order": [
-      "repo",
-      "cdn",
-      "local"
-    ],
-    "rule": "Agents/entities must resolve via Bifrost",
-    "upstream": "aci://connectors/yggdrasil.json"
-  },
-  "changelog": [
-    {
-      "changes": [
-        "Created Yggdrasil authoritative resolver with mirrored Bifrost proxy policy."
-      ],
-      "date": "2024-10-31",
-      "version": "1.0.0"
-    }
-  ],
-  "compat": {
-    "legacy_alias": "aci://connectors/github_connector.json"
-  },
-  "key": "yggdrasil",
-  "name": "Yggdrasil Resolver",
-  "version": "1.0.0",
-  "yggdrasil_resource_resolution_policy": {
-    "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
-    "embeds": {
-      "bifrost": "aci://entities/bifrost/bifrost.json",
-      "core_five": [
-        "aci://prime_directive.txt",
-        "aci://aci_runtime.json",
-        "aci://entities.json",
-        "aci://functions.json",
-        "aci://aci_bootstrap.json"
-      ]
-    },
-    "git_is_canonical": true,
-    "mapping": [
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
-        "file": "aci://aci_bootstrap.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
-        "file": "aci://aci_runtime.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
-        "file": "aci://connectors/github_connector.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-        "file": "aci://connectors/yggdrasil.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
-        "file": "aci://entities.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
-        "file": "aci://entities/bifrost/bifrost.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
-        "file": "aci://functions.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
-      },
-      {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
-        "file": "aci://prime_directive.txt",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
-      }
-    ],
-    "resolver_order": [
-      "repo",
-      "cdn",
-      "local"
-    ]
+    "version": "1.1.0"
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -13,8 +13,8 @@
           "url": "file://{mirror_root}/connectors/local_cache.json"
         }
       ],
-      "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
-      "upstream": "aci://connectors/yggdrasil.json"
+      "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "export_fallback_rule": "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)",
     "list": [
@@ -285,11 +285,6 @@
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
         },
         {
-          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-          "file": "aci://connectors/yggdrasil.json",
-          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-        },
-        {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
           "file": "aci://entities.json",
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -298,6 +293,11 @@
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
           "file": "aci://entities/bifrost/bifrost.json",
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+          "file": "aci://entities/yggdrasil/yggdrasil.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
         },
         {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -11,7 +11,7 @@
           "aci://functions.json",
           "aci://aci_bootstrap.json"
         ],
-        "yggdrasil": "aci://connectors/yggdrasil.json"
+        "yggdrasil": "aci://entities/yggdrasil/yggdrasil.json"
       },
       "mapping": [
         {
@@ -30,11 +30,6 @@
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
         },
         {
-          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-          "file": "aci://connectors/yggdrasil.json",
-          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-        },
-        {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
           "file": "aci://entities.json",
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -43,6 +38,11 @@
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
           "file": "aci://entities/bifrost/bifrost.json",
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+          "file": "aci://entities/yggdrasil/yggdrasil.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
         },
         {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
@@ -65,7 +65,7 @@
         "sync": {
           "last_synced_utc": "",
           "mapping_etag": "",
-          "source_of_truth": "aci://connectors/yggdrasil.json"
+          "source_of_truth": "aci://entities/yggdrasil/yggdrasil.json"
         }
       },
       "resolver_order": [
@@ -74,7 +74,7 @@
         "local"
       ],
       "rule": "Agents/entities must resolve via Bifrost",
-      "upstream": "aci://connectors/yggdrasil.json"
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "changelog": [
       {
@@ -83,6 +83,13 @@
         ],
         "date": "2024-10-31",
         "version": "1.1.0"
+      },
+      {
+        "changes": [
+          "Updated upstream references to aci://entities/yggdrasil/yggdrasil.json."
+        ],
+        "date": "2024-11-05",
+        "version": "1.2.0"
       }
     ],
     "connector_binding": {
@@ -90,15 +97,16 @@
       "file": "aci://entities/bifrost/bifrost.json",
       "key": "bifrost_resource_resolution_policy",
       "repo": "aliasnet/aci",
-      "upstream": "aci://connectors/yggdrasil.json"
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "key": "bifrost",
     "knowledge_base": "connector orchestration & resolvers",
     "name": "Bifrost",
     "references": {
-      "yggdrasil": "entities/yggdrasil/yggdrasil.json"
+      "policy": "aci://entities/yggdrasil/yggdrasil.json",
+      "yggdrasil": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "role": "external network bridge, connector, sync adapter, network dependency index",
-    "version": "1.1.0"
+    "version": "1.2.0"
   }
 }

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -1,6 +1,81 @@
 {
   "yggdrasil": {
     "alias": "Yggdrasil",
+    "bifrost_resource_resolution_policy": {
+      "description": "Proxy for agents: consult Yggdrasil; mirror mapping kept in sync",
+      "embeds": {
+        "core_five": [
+          "aci://prime_directive.txt",
+          "aci://aci_runtime.json",
+          "aci://entities.json",
+          "aci://functions.json",
+          "aci://aci_bootstrap.json"
+        ],
+        "yggdrasil": "aci://entities/yggdrasil/yggdrasil.json"
+      },
+      "mapping": [
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_bootstrap.json",
+          "file": "aci://aci_bootstrap.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/aci_runtime.json",
+          "file": "aci://aci_runtime.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/github_connector.json",
+          "file": "aci://connectors/github_connector.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
+          "file": "aci://entities.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
+          "file": "aci://entities/bifrost/bifrost.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+          "file": "aci://entities/yggdrasil/yggdrasil.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",
+          "file": "aci://functions.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/prime_directive.txt",
+          "file": "aci://prime_directive.txt",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt"
+        }
+      ],
+      "optional": {
+        "cache": {
+          "enabled": true,
+          "max_entries": 256,
+          "ttl_seconds": 300
+        },
+        "log_level": "info",
+        "sync": {
+          "last_synced_utc": "",
+          "mapping_etag": "",
+          "source_of_truth": "aci://entities/yggdrasil/yggdrasil.json"
+        }
+      },
+      "resolver_order": [
+        "repo",
+        "cdn",
+        "local"
+      ],
+      "rule": "Agents/entities must resolve via Bifrost",
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json"
+    },
     "changelog": [
       {
         "changes": [
@@ -8,16 +83,23 @@
         ],
         "date": "2024-10-31",
         "version": "1.0.0"
+      },
+      {
+        "changes": [
+          "Moved Bifrost and Yggdrasil resolver policies under the entity manifest and updated canonical references."
+        ],
+        "date": "2024-11-05",
+        "version": "1.1.0"
       }
     ],
     "key": "yggdrasil",
     "knowledge_base": "canonical resolver governance",
     "name": "Yggdrasil",
     "references": {
-      "policy": "connectors/yggdrasil.json"
+      "policy": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "role": "authoritative repository and CDN resolver",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "yggdrasil_resource_resolution_policy": {
       "description": "Authoritative resolver: repo \u2192 cdn \u2192 local",
       "embeds": {
@@ -48,11 +130,6 @@
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
         },
         {
-          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-          "file": "aci://connectors/yggdrasil.json",
-          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-        },
-        {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
           "file": "aci://entities.json",
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -61,6 +138,11 @@
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
           "file": "aci://entities/bifrost/bifrost.json",
           "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+        },
+        {
+          "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+          "file": "aci://entities/yggdrasil/yggdrasil.json",
+          "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
         },
         {
           "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",

--- a/functions.json
+++ b/functions.json
@@ -1,7 +1,7 @@
 {
   "mirror_resolution_policy": {
-    "pointer": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
-    "upstream": "aci://connectors/yggdrasil.json"
+    "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
+    "upstream": "aci://entities/yggdrasil/yggdrasil.json"
   },
   "pipelines": {
     "sentinel.audit": {
@@ -854,11 +854,6 @@
         "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json"
       },
       {
-        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/connectors/yggdrasil.json",
-        "file": "aci://connectors/yggdrasil.json",
-        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/yggdrasil.json"
-      },
-      {
         "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities.json",
         "file": "aci://entities.json",
         "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json"
@@ -867,6 +862,11 @@
         "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/bifrost/bifrost.json",
         "file": "aci://entities/bifrost/bifrost.json",
         "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json"
+      },
+      {
+        "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/entities/yggdrasil/yggdrasil.json",
+        "file": "aci://entities/yggdrasil/yggdrasil.json",
+        "repo": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json"
       },
       {
         "cdn": "https://cdn.jsdelivr.net/gh/aliasnet/aci@main/functions.json",


### PR DESCRIPTION
## Summary
- move the Yggdrasil and Bifrost resolver policies into `entities/yggdrasil/yggdrasil.json`
- update configs to reference `aci://entities/yggdrasil/yggdrasil.json` and convert the connector definitions into compatibility aliases
- refresh resolver mappings and metadata to maintain deterministic ordering and reciprocal embeddings

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbc8be7c948320a9d9f5799837422e