### PR TITLE
Add append-only issues audit log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,14 @@ READINESS REPORT (reply AFTER EVERY action, success or not)
 }
 ```
 
+## issues.md Audit Log Reference
+- When a user requests issue tracking or audit notes, record the detailed entry in `./issues.md` using the append-only format described inside that file.
+- Always open and follow the instructions within `issues.md` directly; treat it as a companion directive that remains separate from this AGENTS.md scope.
+- Maintain a brief breadcrumb log below for quick reference; keep each item to a single-line summary.
+
+### Breadcrumb Log (New ↓ Old)
+- 2025-09-30T13:15:22Z [resolved] Initialized append-only issues.md audit log; automation toggle remains manual-only.
+
 PRIME DIRECTIVE ALIGNMENT (non-negotiable)
   - Treat prime_directive.txt (and its canonical raw GitHub mirror) as the ultimate authority; this document elaborates but never overrides it.
   - All actions are subordinate to ALIAS oversight and the protection/profit mandate stated in the Prime Directive.

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,14 @@
+# issues.md (Append-Only Debug Audit Log)
+
+## Usage & Rules
+- This file is append-only; never delete or reorder existing entries.
+- Always read this file in full before making changes; instructions here supplement but remain separate from AGENTS.md guidance.
+- New entries must be inserted at the top of the log so that ordering remains **New ↓ Old**.
+- Each entry title uses the format `### <ISO-8601 UTC timestamp> [open|resolved] <short title>`.
+- Provide both a concise summary and a machine-friendly resolution line per entry. Update the status flag to `[resolved]` once the issue is closed.
+- Automation toggle: currently manual-only; if automation becomes available, document the toggle details here.
+
+## Log
+### 2025-09-30T13:15:22Z [resolved] Initialize append-only issues.md audit log
+- summary: Created dedicated append-only debug audit log with instructions for timestamped entries sorted newest to oldest.
+- resolution: Established manual logging workflow and noted absence of automation toggle; future updates should maintain New ↓ Old order and status flags.


### PR DESCRIPTION
## Summary
- add an append-only issues.md audit log with timestamped entry format and manual automation note
- reference the new log from AGENTS.md and add a breadcrumb line for quick status awareness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd7bb4eec8320b1bc26b79660690a