### PR TITLE
Improve process log add CLI parsing

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -864,7 +864,7 @@
         "pipeline": "process.logs.init"
       },
       {
-        "pattern": "^process\\s+log\\s+add$",
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.*?)(?=\\s*(?:--topic\\s+\\S+|--identity\\s+\\S+)?\\s*(?:--topic\\s+\\S+|--identity\\s+\\S+)?\\s*$)(?:(?=.*\\s--topic\\s+(?P<topic>[^\"\\s]+)\\s*(?:--identity\\s+[^\"\\s]+)?\\s*$))?(?:(?=.*\\s--identity\\s+(?P<identity>[^\"\\s]+)\\s*(?:--topic\\s+[^\"\\s]+)?\\s*$))?(?:\\s+--(?:topic|identity)\\s+[^\"\\s]+){0,2}$",
         "pipeline": "process.logs.append"
       },
       {


### PR DESCRIPTION
## Summary
- update the `process log add` CLI regex to capture the event and full summary text while still detecting optional topic and identity flags

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68dc02a777e48320ac4b1c157e13531e