### PR TITLE
Adjust process log add CLI parsing

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -864,7 +864,23 @@
         "pipeline": "process.logs.init"
       },
       {
-        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.*?)(?=\\s*(?:--topic\\s+\\S+|--identity\\s+\\S+)?\\s*(?:--topic\\s+\\S+|--identity\\s+\\S+)?\\s*$)(?:(?=.*\\s--topic\\s+(?P<topic>[^\"\\s]+)\\s*(?:--identity\\s+[^\"\\s]+)?\\s*$))?(?:(?=.*\\s--identity\\s+(?P<identity>[^\"\\s]+)\\s*(?:--topic\\s+[^\"\\s]+)?\\s*$))?(?:\\s+--(?:topic|identity)\\s+[^\"\\s]+){0,2}$",
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
         "pipeline": "process.logs.append"
       },
       {


### PR DESCRIPTION
## Summary
- replace the process log add CLI regex with a set of targeted patterns so the summary capture can be greedy without losing optional flag parsing
- ensure commands with optional --topic/--identity flags continue to route to process.logs.append while summaries that contain --topic text are preserved

## Testing
- python - <<'PY' ... # verify CLI patterns and captured groups
- python - <<'PY' ... # validate process log schema for entries with and without optional flags


------
https://chatgpt.com/codex/tasks/task_e_68dc157e0b308320939ca14d93bf3302