### PR TITLE
Fix process log add CLI argument capture

### DIFF
--- a/aci_commands.json
+++ b/aci_commands.json
@@ -12,6 +12,23 @@
         "oracle": "oracle.json",
         "hivemind": "entities/hivemind/hivemind.json"
       }
+    },
+    ":process.log": {
+      "description": "Pseudo-CLI wrapper for session-scoped process log workflows (init, add, export).",
+      "usage": [
+        ":process.log init [--topic <topic>]",
+        ":process.log add --event <event> --summary <summary> [--topic <topic>] [--identity <identity>]",
+        ":process.log export"
+      ],
+      "pipelines": {
+        "add": "process.logs.append",
+        "export": "process.logs.export",
+        "init": "process.logs.init"
+      },
+      "notes": [
+        "Acts as a difference-encoded prompt wrapper so LLM agents can call the governed pipelines without regex conflicts.",
+        "Optional fields (topic, details, citations) default through storage when omitted; event and summary remain required."
+      ]
     }
   }
 }

--- a/functions.json
+++ b/functions.json
@@ -720,23 +720,18 @@
           }
         },
         {
-          "call": "_store.set",
+          "call": "slugify",
           "map": {
-            "key": "process_logs.entry_topic",
-            "value": "${process_logs.topic_slug}"
+            "text": "$params.topic",
+            "default": "${process_logs.topic_slug}"
           }
         },
         {
-          "if": "$params.topic != null",
-          "then": [
-            {
-              "call": "_store.set",
-              "map": {
-                "key": "process_logs.entry_topic",
-                "value": "$params.topic"
-              }
-            }
-          ]
+          "call": "_store.set",
+          "map": {
+            "key": "process_logs.entry_topic",
+            "value": "$steps.4.slug"
+          }
         },
         {
           "call": "_store.set",
@@ -916,11 +911,39 @@
         "pipeline": "process.logs.init"
       },
       {
-        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)(?:\\s+--topic\\s+(?P<topic>\\S+))?(?:\\s+--identity\\s+(?P<identity>\\S+))?\\s+--summary\\s+(?P<summary>.+)$",
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
         "pipeline": "process.logs.append"
       },
       {
-        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)(?:\\s+--identity\\s+(?P<identity>\\S+))?(?:\\s+--topic\\s+(?P<topic>\\S+))?\\s+--summary\\s+(?P<summary>.+)$",
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--topic\\s+(?P<topic>\\S+)\\s+--identity\\s+(?P<identity>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--identity\\s+(?P<identity>\\S+)\\s+--topic\\s+(?P<topic>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--topic\\s+(?P<topic>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--identity\\s+(?P<identity>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
         "pipeline": "process.logs.append"
       },
       {

--- a/library/staging/functions.json.stage.txt
+++ b/library/staging/functions.json.stage.txt
@@ -722,23 +722,18 @@
           }
         },
         {
-          "call": "_store.set",
+          "call": "slugify",
           "map": {
-            "key": "process_logs.entry_topic",
-            "value": "${process_logs.topic_slug}"
+            "text": "$params.topic",
+            "default": "${process_logs.topic_slug}"
           }
         },
         {
-          "if": "$params.topic != null",
-          "then": [
-            {
-              "call": "_store.set",
-              "map": {
-                "key": "process_logs.entry_topic",
-                "value": "$params.topic"
-              }
-            }
-          ]
+          "call": "_store.set",
+          "map": {
+            "key": "process_logs.entry_topic",
+            "value": "$steps.4.slug"
+          }
         },
         {
           "call": "_store.set",
@@ -918,7 +913,39 @@
         "pipeline": "process.logs.init"
       },
       {
-        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)(?=(?:\\s+--(?:topic|identity)\\b|$))(?:\\s+--topic\\s+(?P<topic>.+?)(?=(?:\\s+--identity\\b|$)))?(?:\\s+--identity\\s+(?P<identity>\\S+))?$",
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--topic\\s+(?P<topic>\\S+)\\s+--identity\\s+(?P<identity>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--identity\\s+(?P<identity>\\S+)\\s+--topic\\s+(?P<topic>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--topic\\s+(?P<topic>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--identity\\s+(?P<identity>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
         "pipeline": "process.logs.append"
       },
       {

--- a/library/staging/functions.json.stage.txt
+++ b/library/staging/functions.json.stage.txt
@@ -1,3 +1,5 @@
+# STAGING COPY - Nonfunctional stub
+
 {
   "mirror_resolution_policy": {
     "key": "github_connector",
@@ -916,11 +918,7 @@
         "pipeline": "process.logs.init"
       },
       {
-        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)(?:\\s+--topic\\s+(?P<topic>\\S+))?(?:\\s+--identity\\s+(?P<identity>\\S+))?\\s+--summary\\s+(?P<summary>.+)$",
-        "pipeline": "process.logs.append"
-      },
-      {
-        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)(?:\\s+--identity\\s+(?P<identity>\\S+))?(?:\\s+--topic\\s+(?P<topic>\\S+))?\\s+--summary\\s+(?P<summary>.+)$",
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)(?=(?:\\s+--(?:topic|identity)\\b|$))(?:\\s+--topic\\s+(?P<topic>.+?)(?=(?:\\s+--identity\\b|$)))?(?:\\s+--identity\\s+(?P<identity>\\S+))?$",
         "pipeline": "process.logs.append"
       },
       {

--- a/library/staging/wrappers/process_logs/process_log_schema.json.stage.txt
+++ b/library/staging/wrappers/process_logs/process_log_schema.json.stage.txt
@@ -1,0 +1,52 @@
+# STAGING COPY - Nonfunctional stub
+
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ACI Process Log Line (JSONL)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "ts",
+    "identity",
+    "event",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "agi.process.log.v1"
+    },
+    "ts": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp"
+    },
+    "identity": {
+      "type": "string",
+      "description": "Logical actor (e.g., AGI, Alice, Architect)"
+    },
+    "topic": {
+      "type": "string",
+      "description": "Optional topical thread name/slug"
+    },
+    "event": {
+      "type": "string",
+      "description": "Event key (e.g., init, constraints, notation.audit)"
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-line human/machine friendly synopsis"
+    },
+    "details": {
+      "type": "object",
+      "description": "Structured payload, free-form JSON"
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Compact names/years strings; no links"
+    }
+  }
+}

--- a/library/staging/wrappers/process_logs/process_logs.json.stage.txt
+++ b/library/staging/wrappers/process_logs/process_logs.json.stage.txt
@@ -1,0 +1,47 @@
+# STAGING COPY - Nonfunctional stub
+
+{
+  "abstract": "Emits structured JSONL process logs for any identity (AGI, Alice, Architect, etc.). Optimized for append-only, audit-friendly traces.",
+  "alias": "Process Logs",
+  "auto_export": false,
+  "changelog": [
+    {
+      "date": "2025-10-01",
+      "notes": [
+        "Normalize optional CLI parameters with governed defaults before schema validation to keep append flow resilient."
+      ],
+      "version": "1.0.2"
+    },
+    {
+      "date": "2025-09-30",
+      "notes": [
+        "Return structured JSON responses from init/append/export pipelines for predictable CLI consumption."
+      ],
+      "version": "1.0.1"
+    },
+    {
+      "date": "2025-09-29",
+      "notes": [
+        "Initial wrapper specification enabling append-only process log JSONL lines with agi.process.log.v1 schema enforcement."
+      ],
+      "version": "1.0.0"
+    }
+  ],
+  "functions": [
+    "process.logs.init",
+    "process.logs.append",
+    "process.logs.export"
+  ],
+  "key": "process_logs",
+  "knowledge_base": "observability & audit pipelines",
+  "name": "Process Logs",
+  "notes": "Identity is a required field; default is 'AGI' when unspecified.",
+  "role": "append-only process logging",
+  "schema": "library/wrappers/process_logs/process_log_schema.json",
+  "storage": {
+    "append_only": true,
+    "file_naming": "proc_${session_id}_${topic_slug}_${date}.jsonl.json",
+    "root": "memory/process_logs"
+  },
+  "version": "1.0.2"
+}

--- a/library/staging/wrappers/process_logs/process_logs.json.stage.txt
+++ b/library/staging/wrappers/process_logs/process_logs.json.stage.txt
@@ -6,6 +6,13 @@
   "auto_export": false,
   "changelog": [
     {
+      "date": "2025-10-02",
+      "notes": [
+        "Allow CLI optional flags before or after the summary token and slugify per-entry topics while composing structured responses."
+      ],
+      "version": "1.0.3"
+    },
+    {
       "date": "2025-10-01",
       "notes": [
         "Normalize optional CLI parameters with governed defaults before schema validation to keep append flow resilient."
@@ -43,5 +50,5 @@
     "file_naming": "proc_${session_id}_${topic_slug}_${date}.jsonl.json",
     "root": "memory/process_logs"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/library/wrappers/process_logs/process_log_schema.json
+++ b/library/wrappers/process_logs/process_log_schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ACI Process Log Line (JSONL)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "ts",
+    "identity",
+    "event",
+    "summary"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "agi.process.log.v1"
+    },
+    "ts": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp"
+    },
+    "identity": {
+      "type": "string",
+      "description": "Logical actor (e.g., AGI, Alice, Architect)"
+    },
+    "topic": {
+      "type": "string",
+      "description": "Optional topical thread name/slug"
+    },
+    "event": {
+      "type": "string",
+      "description": "Event key (e.g., init, constraints, notation.audit)"
+    },
+    "summary": {
+      "type": "string",
+      "description": "One-line human/machine friendly synopsis"
+    },
+    "details": {
+      "type": "object",
+      "description": "Structured payload, free-form JSON"
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Compact names/years strings; no links"
+    }
+  }
+}

--- a/library/wrappers/process_logs/process_logs.json
+++ b/library/wrappers/process_logs/process_logs.json
@@ -4,6 +4,13 @@
   "auto_export": false,
   "changelog": [
     {
+      "date": "2025-10-02",
+      "notes": [
+        "Allow CLI optional flags before or after the summary token and slugify per-entry topics while composing structured responses."
+      ],
+      "version": "1.0.3"
+    },
+    {
       "date": "2025-10-01",
       "notes": [
         "Normalize optional CLI parameters with governed defaults before schema validation to keep append flow resilient."
@@ -41,5 +48,5 @@
     "file_naming": "proc_${session_id}_${topic_slug}_${date}.jsonl.json",
     "root": "memory/process_logs"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/library/wrappers/process_logs/process_logs.json
+++ b/library/wrappers/process_logs/process_logs.json
@@ -1,0 +1,45 @@
+{
+  "abstract": "Emits structured JSONL process logs for any identity (AGI, Alice, Architect, etc.). Optimized for append-only, audit-friendly traces.",
+  "alias": "Process Logs",
+  "auto_export": false,
+  "changelog": [
+    {
+      "date": "2025-10-01",
+      "notes": [
+        "Normalize optional CLI parameters with governed defaults before schema validation to keep append flow resilient."
+      ],
+      "version": "1.0.2"
+    },
+    {
+      "date": "2025-09-30",
+      "notes": [
+        "Return structured JSON responses from init/append/export pipelines for predictable CLI consumption."
+      ],
+      "version": "1.0.1"
+    },
+    {
+      "date": "2025-09-29",
+      "notes": [
+        "Initial wrapper specification enabling append-only process log JSONL lines with agi.process.log.v1 schema enforcement."
+      ],
+      "version": "1.0.0"
+    }
+  ],
+  "functions": [
+    "process.logs.init",
+    "process.logs.append",
+    "process.logs.export"
+  ],
+  "key": "process_logs",
+  "knowledge_base": "observability & audit pipelines",
+  "name": "Process Logs",
+  "notes": "Identity is a required field; default is 'AGI' when unspecified.",
+  "role": "append-only process logging",
+  "schema": "library/wrappers/process_logs/process_log_schema.json",
+  "storage": {
+    "append_only": true,
+    "file_naming": "proc_${session_id}_${topic_slug}_${date}.jsonl.json",
+    "root": "memory/process_logs"
+  },
+  "version": "1.0.2"
+}


### PR DESCRIPTION
## Summary
- ensure the `process log add` CLI regex captures the required `--event` and `--summary` arguments while supporting optional `--topic` and `--identity` flags before the summary token

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da7ccaf97c8320ac5775c420196cd4