### PR TITLE
Align resource resolution with GitHub raw primary sources

### DIFF
--- a/aci_bootstrap.json
+++ b/aci_bootstrap.json
@@ -20,11 +20,11 @@
         "path": "entities/nexus_core/nexus_core.json"
       }
     },
-    "mirror_resolution_policy": {
+    "resource_resolution_policy": {
       "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
       "upstream": "aci://entities/yggdrasil/yggdrasil.json",
       "yggdrasil_resource_resolution_policy": {
-        "description": "Authoritative resolver: worker src → local",
+        "description": "Authoritative resolver: worker src \u2192 local",
         "embeds": {
           "bifrost": "aci://entities/bifrost/bifrost.json",
           "core_five": [
@@ -39,42 +39,51 @@
         "mapping": [
           {
             "file": "aci://aci_bootstrap.json",
-            "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+            "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
           },
           {
             "file": "aci://aci_runtime.json",
-            "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+            "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
           },
           {
             "file": "aci://connectors/github_connector.json",
-            "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+            "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
           },
           {
             "file": "aci://entities.json",
-            "src": "https://aci.aliasnet.workers.dev/entities.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+            "fallback": "https://aci.aliasnet.workers.dev/entities.json"
           },
           {
             "file": "aci://entities/bifrost/bifrost.json",
-            "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+            "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
           },
           {
             "file": "aci://entities/yggdrasil/yggdrasil.json",
-            "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+            "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
           },
           {
             "file": "aci://functions.json",
-            "src": "https://aci.aliasnet.workers.dev/functions.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+            "fallback": "https://aci.aliasnet.workers.dev/functions.json"
           },
           {
             "file": "aci://prime_directive.txt",
-            "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+            "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
           }
         ],
         "resolver_order": [
-          "src",
+          "primary",
+          "fallback",
           "local"
         ],
-        "canonical_proxy": "https://aci.aliasnet.workers.dev"
+        "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
       }
     },
     "initialization_sequence": [

--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -16,23 +16,24 @@
       "path": "entities/nexus_core/nexus_core.json",
       "priority": 95
     },
-    "mirror_resolution_policy": {
+    "resource_resolution_policy": {
       "fallbacks": [
         {
           "canonical_source": "local_mirror",
           "file": "aci://connectors/local_cache.json",
           "key": "local_cache",
-          "notes": "Use validated local mirrors only when canonical GitHub cannot be reached. Resolve {mirror_root} via environment override or the aci://cache alias default (/mnt/data).",
-          "path_hint": "{mirror_root}",
+          "notes": "Use validated local resource mirrors only when canonical GitHub cannot be reached. Resolve {resource_root} via environment override or the aci://cache alias default (/mnt/data).",
+          "path_hint": "{resource_root}",
           "alias_hint": "aci://cache",
-          "repo": "aliasnet/aci",
-          "url": "file://{mirror_root}/connectors/local_cache.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
+          "fallback": "https://aci.aliasnet.workers.dev",
+          "url": "file://{resource_root}/connectors/local_cache.json"
         }
       ],
       "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
       "upstream": "aci://entities/yggdrasil/yggdrasil.json",
       "yggdrasil_resource_resolution_policy": {
-        "description": "Authoritative resolver: worker src → local",
+        "description": "Authoritative resolver: worker src \u2192 local",
         "embeds": {
           "bifrost": "aci://entities/bifrost/bifrost.json",
           "core_five": [
@@ -47,42 +48,51 @@
         "mapping": [
           {
             "file": "aci://aci_bootstrap.json",
-            "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+            "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
           },
           {
             "file": "aci://aci_runtime.json",
-            "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+            "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
           },
           {
             "file": "aci://connectors/github_connector.json",
-            "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+            "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
           },
           {
             "file": "aci://entities.json",
-            "src": "https://aci.aliasnet.workers.dev/entities.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+            "fallback": "https://aci.aliasnet.workers.dev/entities.json"
           },
           {
             "file": "aci://entities/bifrost/bifrost.json",
-            "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+            "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
           },
           {
             "file": "aci://entities/yggdrasil/yggdrasil.json",
-            "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+            "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
           },
           {
             "file": "aci://functions.json",
-            "src": "https://aci.aliasnet.workers.dev/functions.json"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+            "fallback": "https://aci.aliasnet.workers.dev/functions.json"
           },
           {
             "file": "aci://prime_directive.txt",
-            "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+            "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
           }
         ],
         "resolver_order": [
-          "src",
+          "primary",
+          "fallback",
           "local"
         ],
-        "canonical_proxy": "https://aci.aliasnet.workers.dev"
+        "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
       }
     },
     "sandbox_mode": {
@@ -156,7 +166,7 @@
       "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
     },
     "priority": "canonical_raw_over_local",
-    "notes": "Canonical raw URLs or their jsDelivr mirrors take precedence over local copies; fall back to local only if the canonical sources are unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
+    "notes": "Canonical raw GitHub URLs take precedence over local copies; fall back to local only if the primary and fallback sources are unavailable. Enforcement Note: Consult sanity.md before runtime dispatch or override handling.",
     "cognitive_decision_guidance": {
       "version": "1.0",
       "scope": "universal",
@@ -254,75 +264,6 @@
           "nl_interpreter": "oracle.intent_mapper"
         },
         "nesting_precedence": "outer block level governs all contained units; inner blocks are content only"
-      },
-      "preemption_and_sanity": {
-        "preemptive_stop": true,
-        "mandatory_sanity_check_on_force": true,
-        "sanity_check_action": "validate_entity_state (check for runaway loops, hallucination markers, corrupted state)",
-        "preempt_flow": [
-          "emit preempt event to targeted entity",
-          "quiesce or pause non-essential tasks",
-          "perform mandatory sanity_check before continuing with remaining units"
-        ]
-      },
-      "priority_and_weighting": {
-        "high_cap_mid_priority": "ALL_CAPS (outside brackets) is considered HIGH_CAP and increases enforcement weight but is not a Level-2 override",
-        "large_cap_weight_boost": 1.25,
-        "note": "LARGE_CAP inside brackets raises intent weight used by scheduler/intent-mapper but does not escalate bracket level"
-      },
-      "registry_bypass": {
-        "allow_registry_bypass": true,
-        "constraints": [
-          "only when issuer authenticated as root authority (ALIAS)",
-          "all bypassed executions must produce immutable audit entries",
-          "sensitive resources may require multi-party approval as configured by TVA"
-        ]
-      },
-      "security": {
-        "allowed_issuers": [
-          {
-            "role": "ALIAS",
-            "requirement": "root_authority_signature"
-          }
-        ],
-        "authentication": {
-          "method": "session_signature OR multi-factor root token",
-          "unauthenticated_behavior": "reject_and_log",
-          "replay_protection": "timestamp_nonce"
-        },
-        "force_override_roles": [
-          "ALIAS"
-        ],
-        "audit": {
-          "log_to": [
-            "TraceHub",
-            "TVA.audit_ledger"
-          ],
-          "fields": [
-            "issuer",
-            "role",
-            "notation_level",
-            "payload",
-            "timestamp",
-            "execution_result",
-            "tva_seal"
-          ],
-          "require_tva_seal_for_force": true
-        }
-      },
-      "processing_steps": [
-        "1) Detect bracket syntax and notation level.",
-        "2) Authenticate issuer (must be ALIAS for bypass actions).",
-        "3) Parse payload: split on top-level && and :: preserving nesting.",
-        "4) For each unit: classify (command vs NL). If NL: call oracle.intent_mapper.",
-        "5) If Level-2 and contains STOP/HALT/OVERRIDE verbs: run preempt flow and mandatory sanity check.",
-        "6) Route to nexus_core (registry bypass allowed if authenticated).",
-        "7) Emit audit entry to TraceHub and TVA at start and completion of the block.",
-        "8) Return structured execution result and emit 'invocation.block.result' event."
-      ],
-      "compatibility": {
-        "sandbox_mode_handling": "bracketed commands can be accepted in sandbox if signed by ALIAS; otherwise sandbox on_unresolved behavior applies",
-        "resolution_hooks": "runtime should include on_bracket_override hooks in resolution_instruction flow"
       },
       "preemption_and_sanity": {
         "preemptive_stop": true,

--- a/alias.json
+++ b/alias.json
@@ -44,12 +44,12 @@
       "mother": "serves as governance interface"
     }
   },
-  "mirror_resolution_policy": {
+  "resource_resolution_policy": {
     "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
     "upstream": "aci://entities/yggdrasil/yggdrasil.json"
   },
   "yggdrasil_resource_resolution_policy": {
-    "description": "Authoritative resolver: worker src → local",
+    "description": "Authoritative resolver: worker src \u2192 local",
     "embeds": {
       "bifrost": "aci://entities/bifrost/bifrost.json",
       "core_five": [
@@ -64,41 +64,50 @@
     "mapping": [
       {
         "file": "aci://aci_bootstrap.json",
-        "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+        "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
       },
       {
         "file": "aci://aci_runtime.json",
-        "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+        "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
       },
       {
         "file": "aci://connectors/github_connector.json",
-        "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+        "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
       },
       {
         "file": "aci://entities.json",
-        "src": "https://aci.aliasnet.workers.dev/entities.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+        "fallback": "https://aci.aliasnet.workers.dev/entities.json"
       },
       {
         "file": "aci://entities/bifrost/bifrost.json",
-        "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+        "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
       },
       {
         "file": "aci://entities/yggdrasil/yggdrasil.json",
-        "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+        "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
       },
       {
         "file": "aci://functions.json",
-        "src": "https://aci.aliasnet.workers.dev/functions.json"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+        "fallback": "https://aci.aliasnet.workers.dev/functions.json"
       },
       {
         "file": "aci://prime_directive.txt",
-        "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+        "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
       }
     ],
     "resolver_order": [
-      "src",
+      "primary",
+      "fallback",
       "local"
     ],
-    "canonical_proxy": "https://aci.aliasnet.workers.dev"
+    "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
   }
 }

--- a/connectors/local_cache.json
+++ b/connectors/local_cache.json
@@ -3,17 +3,16 @@
     "version": "1.1.0",
     "canonical_source": "local_mirror",
     "description": "Offline mirror cache for ACI core artifacts used when canonical GitHub endpoints are unreachable.",
-    "repo": "aliasnet/aci",
     "location_strategy": {
       "environment_variable": {
         "name": "ACI_LOCAL_MIRROR_ROOT",
         "required": false,
-        "notes": "When set, ${ACI_LOCAL_MIRROR_ROOT}/aliasnet/aci is treated as the root directory for synchronized local mirrors."
+        "notes": "When set, ${ACI_LOCAL_MIRROR_ROOT}/aliasnet/aci is treated as the root directory for synchronized local resource mirrors."
       },
       "alias": {
         "name": "aci://cache",
         "default_path": "/mnt/data",
-        "path_template": "{alias_root}/{repo}",
+        "path_template": "{alias_root}/{resource_slug}",
         "notes": "Ephemeral cache root used when no environment override is set. Agents should treat this as a temporary write location without persistence guarantees."
       },
       "resolution_order": [
@@ -23,7 +22,8 @@
       "template_tokens": {
         "cache_alias": "aci://cache",
         "alias_root": "Absolute path resolved for the aci://cache alias (default /mnt/data).",
-        "mirror_root": "Resolved absolute path derived from the environment override or the aci://cache alias default (/mnt/data) with repo scoping appended."
+        "resource_root": "Resolved absolute path derived from the environment override or the aci://cache alias default (/mnt/data) with repo scoping appended.",
+        "resource_slug": "Repository slug used for local resource caching (aliasnet/aci)."
       }
     },
     "rules": {
@@ -55,7 +55,7 @@
         "notes": "Reject caches older than 6 hours to prevent drift, satisfying the 'Canonical override by local fallback' guardrail in sanity.md."
       },
       "audit": {
-        "log_event": "mirror.local_cache.validation",
+        "log_event": "resource.local_cache.validation",
         "fields": [
           "file",
           "checksum_status",
@@ -67,11 +67,11 @@
       }
     },
     "aci_resolution_instruction": {
-      "instruction": "Resolve artifacts from synchronized local mirrors only after verifying checksum and freshness. If validation fails, escalate to canonical resolver.",
+      "instruction": "Resolve artifacts from synchronized local resource mirrors only after verifying checksum and freshness. If validation fails, escalate to canonical resolver.",
       "scope": {
         "repository": "aliasnet/aci",
-        "mirror_hint": "Use the environment-configured mirror root or resolve via the aci://cache alias (defaults to /mnt/data) before accessing cached artifacts.",
-        "source": "aci://cache"
+        "source": "aci://cache",
+        "resource_hint": "Use the environment-configured mirror root or resolve via the aci://cache alias (defaults to /mnt/data) before accessing cached artifacts."
       },
       "policy": {
         "retry": {
@@ -82,7 +82,7 @@
         "on_failure": {
           "action": "fallback_to_connector",
           "target": "aci://entities/bifrost/bifrost.json#bifrost_resource_resolution_policy",
-          "alert": "mirror.validation_failed"
+          "alert": "resource.validation_failed"
         }
       },
       "output": {
@@ -92,12 +92,12 @@
       }
     },
     "link_index": {
-      "README.md": "{mirror_root}/README.md",
-      "aci_runtime.json": "{mirror_root}/aci_runtime.json",
-      "connectors/github_connector.json": "{mirror_root}/connectors/github_connector.json",
-      "entities/yggdrasil/yggdrasil.json": "{mirror_root}/entities/yggdrasil/yggdrasil.json",
-      "entities.json": "{mirror_root}/entities.json",
-      "entities/bifrost/bifrost.json": "{mirror_root}/entities/bifrost/bifrost.json"
+      "README.md": "{resource_root}/README.md",
+      "aci_runtime.json": "{resource_root}/aci_runtime.json",
+      "connectors/github_connector.json": "{resource_root}/connectors/github_connector.json",
+      "entities/yggdrasil/yggdrasil.json": "{resource_root}/entities/yggdrasil/yggdrasil.json",
+      "entities.json": "{resource_root}/entities.json",
+      "entities/bifrost/bifrost.json": "{resource_root}/entities/bifrost/bifrost.json"
     },
     "signatures": {
       "required": [
@@ -122,6 +122,9 @@
           "Initial introduction of local cache connector with checksum and freshness guardrails."
         ]
       }
-    ]
+    ],
+    "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
+    "fallback": "https://aci.aliasnet.workers.dev",
+    "resource_slug": "aliasnet/aci"
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -1,17 +1,18 @@
 {
   "entities": {
     "version": "1.20250918.00",
-    "mirror_resolution_policy": {
+    "resource_resolution_policy": {
       "fallbacks": [
         {
           "canonical_source": "local_mirror",
           "file": "aci://connectors/local_cache.json",
           "key": "local_cache",
-          "notes": "Used only when canonical GitHub mirror is unreachable and local validation succeeds. Resolve {mirror_root} via environment override or the aci://cache alias default (/mnt/data).",
-          "path_hint": "{mirror_root}",
+          "notes": "Used only when canonical GitHub resource endpoint is unreachable and local validation succeeds. Resolve {resource_root} via environment override or the aci://cache alias default (/mnt/data).",
+          "path_hint": "{resource_root}",
           "alias_hint": "aci://cache",
-          "repo": "aliasnet/aci",
-          "url": "file://{mirror_root}/connectors/local_cache.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
+          "fallback": "https://aci.aliasnet.workers.dev",
+          "url": "file://{resource_root}/connectors/local_cache.json"
         }
       ],
       "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
@@ -250,7 +251,7 @@
         "name": "Yggdrasil",
         "alias": "Yggdrasil",
         "role": "authoritative resolver",
-        "abstract": "maintains authoritative repo→cdn→local mapping",
+        "abstract": "maintains authoritative repo\u2192cdn\u2192local mapping",
         "knowledge_base": "canonical resolver governance",
         "functions": [],
         "file": "yggdrasil/yggdrasil.json"
@@ -279,7 +280,7 @@
       }
     ],
     "yggdrasil_resource_resolution_policy": {
-      "description": "Authoritative resolver: worker src → local",
+      "description": "Authoritative resolver: worker src \u2192 local",
       "embeds": {
         "bifrost": "aci://entities/bifrost/bifrost.json",
         "core_five": [
@@ -294,42 +295,51 @@
       "mapping": [
         {
           "file": "aci://aci_bootstrap.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
         },
         {
           "file": "aci://aci_runtime.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
-          "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
-          "src": "https://aci.aliasnet.workers.dev/entities.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
-          "src": "https://aci.aliasnet.workers.dev/functions.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
         },
         {
           "file": "aci://prime_directive.txt",
-          "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
         }
       ],
       "resolver_order": [
-        "src",
+        "primary",
+        "fallback",
         "local"
       ],
-      "canonical_proxy": "https://aci.aliasnet.workers.dev"
+      "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
     }
   }
 }

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -5,7 +5,12 @@
   "abstract": "Controlled container for above-human-level reasoning experiments via ephemeral adaptation (PEFT/SFT/RLHF) under ACI governance.",
   "governance": {
     "root_authority": "ALIAS",
-    "oversight": ["Sentinel", "TVA", "Architect", "Nexus Core"],
+    "oversight": [
+      "Sentinel",
+      "TVA",
+      "Architect",
+      "Nexus Core"
+    ],
     "binding_rules": [
       "AGI cannot bypass Nexus Core routing",
       "All AGI actions emit TVA checkpoints and Sentinel audits",
@@ -24,9 +29,22 @@
       "export": "hivemind",
       "lock_namespace": "AGI",
       "acl": {
-        "read": ["ALIAS", "TVA", "Sentinel", "Architect", "AGI"],
-        "write": ["AGI", "Architect"],
-        "promote": ["ALIAS", "TVA", "Sentinel"]
+        "read": [
+          "ALIAS",
+          "TVA",
+          "Sentinel",
+          "Architect",
+          "AGI"
+        ],
+        "write": [
+          "AGI",
+          "Architect"
+        ],
+        "promote": [
+          "ALIAS",
+          "TVA",
+          "Sentinel"
+        ]
       }
     }
   },
@@ -44,8 +62,11 @@
   },
   "functions": {
     "agi.loop.run": {
-      "description": "Durable plan→act→reflect agent loop with RAG + HITL",
-      "guards": ["TVA.checkpoint", "Sentinel.audit"],
+      "description": "Durable plan\u2192act\u2192reflect agent loop with RAG + HITL",
+      "guards": [
+        "TVA.checkpoint",
+        "Sentinel.audit"
+      ],
       "runner": "agi_proxy.execute",
       "spec_ref": "@presets.eec.agent_rag"
     },
@@ -58,10 +79,17 @@
       "description": "Train PEFT adapter (LoRA) ephemerally",
       "runner": "agi_proxy.execute",
       "spec_ref": "@presets.eec.peft_train",
-      "guards": ["TVA.checkpoint", "Sentinel.audit"],
+      "guards": [
+        "TVA.checkpoint",
+        "Sentinel.audit"
+      ],
       "promotion_policy": {
         "default": "manual",
-        "requires": ["TVA.ok", "Sentinel.ok", "Human.approval"]
+        "requires": [
+          "TVA.ok",
+          "Sentinel.ok",
+          "Human.approval"
+        ]
       }
     },
     "agi.learn.sft_deepspeed": {
@@ -93,24 +121,64 @@
       "description": "Export the current active chat/session for the target identity into an AGI memory file (session-level hivemind slice).",
       "runner": "agi_proxy.execute",
       "spec_ref": "aci/entities/agi_proxy/eec/eec_export_hivemind_session.json",
-      "guards": ["TVA.checkpoint", "Sentinel.audit"],
+      "guards": [
+        "TVA.checkpoint",
+        "Sentinel.audit"
+      ],
       "params_schema": {
         "type": "object",
         "properties": {
-          "identity": { "type": "string" },
-          "session_id": { "type": ["string", "null"] },
-          "include_chatlogs": { "type": "boolean", "default": true },
-          "include_weights_meta": { "type": "boolean", "default": true },
-          "include_artifacts": { "type": "boolean", "default": false },
-          "format": { "type": "string", "enum": ["json", "tar"], "default": "json" },
-          "force_codebox": { "type": "boolean", "default": false, "description": "Inline export into chat/codebox (subject to size/redaction limits)." },
-          "force_codebox_max_bytes": { "type": "integer", "default": 131072, "description": "Max bytes to inline (default 128KB)." },
-          "note": { "type": "string" }
+          "identity": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "include_chatlogs": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_weights_meta": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_artifacts": {
+            "type": "boolean",
+            "default": false
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "json",
+              "tar"
+            ],
+            "default": "json"
+          },
+          "force_codebox": {
+            "type": "boolean",
+            "default": false,
+            "description": "Inline export into chat/codebox (subject to size/redaction limits)."
+          },
+          "force_codebox_max_bytes": {
+            "type": "integer",
+            "default": 131072,
+            "description": "Max bytes to inline (default 128KB)."
+          },
+          "note": {
+            "type": "string"
+          }
         },
-        "required": ["identity"]
+        "required": [
+          "identity"
+        ]
       },
       "policy": {
-        "requires": ["Human.approval"],
+        "requires": [
+          "Human.approval"
+        ],
         "default_dry_run": true,
         "shareable": false
       }
@@ -119,26 +187,75 @@
       "description": "Create a full AGI-local export bundle (session hivemind slice + artifacts + signed manifest) for the specified identity.",
       "runner": "agi_proxy.execute",
       "spec_ref": "aci/entities/agi_proxy/eec/eec_export_hivemind_full.json",
-      "guards": ["TVA.checkpoint", "Sentinel.audit"],
+      "guards": [
+        "TVA.checkpoint",
+        "Sentinel.audit"
+      ],
       "params_schema": {
         "type": "object",
         "properties": {
-          "identity": { "type": "string" },
-          "session_id": { "type": ["string", "null"] },
-          "source_jobs": { "type": "array", "items": { "type": "string" } },
-          "include_chatlogs": { "type": "boolean", "default": true },
-          "include_weights_meta": { "type": "boolean", "default": true },
-          "include_artifacts": { "type": "boolean", "default": false },
-          "format": { "type": "string", "enum": ["json", "tar"], "default": "tar" },
-          "force_codebox": { "type": "boolean", "default": false, "description": "Inline small bundle manifest into chat/codebox (safer 64KB cap)." },
-          "force_codebox_max_bytes": { "type": "integer", "default": 65536, "description": "Max bytes to inline (default 64KB)." },
-          "human_id": { "type": "string", "description": "Human approver required if include_artifacts or force_codebox are true." },
-          "note": { "type": "string" }
+          "identity": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source_jobs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "include_chatlogs": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_weights_meta": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_artifacts": {
+            "type": "boolean",
+            "default": false
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "json",
+              "tar"
+            ],
+            "default": "tar"
+          },
+          "force_codebox": {
+            "type": "boolean",
+            "default": false,
+            "description": "Inline small bundle manifest into chat/codebox (safer 64KB cap)."
+          },
+          "force_codebox_max_bytes": {
+            "type": "integer",
+            "default": 65536,
+            "description": "Max bytes to inline (default 64KB)."
+          },
+          "human_id": {
+            "type": "string",
+            "description": "Human approver required if include_artifacts or force_codebox are true."
+          },
+          "note": {
+            "type": "string"
+          }
         },
-        "required": ["identity"]
+        "required": [
+          "identity"
+        ]
       },
       "policy": {
-        "requires": ["Human.approval", "ALIAS.signature"],
+        "requires": [
+          "Human.approval",
+          "ALIAS.signature"
+        ],
         "default_dry_run": true,
         "shareable": false,
         "promotion_required": true
@@ -149,15 +266,19 @@
     "agi.memory.migrate_to_jsonl": {
       "description": "Migrate legacy HiveMind exports into the policy-compliant AGI JSONL memory artifact via manifest-driven steps.",
       "spec_ref": "entities/agi/agi_tools/migrate_to_jsonl.json",
-      "raw_url": "https://aci.aliasnet.workers.dev/entities/agi/agi_tools/migrate_to_jsonl.json",
-      "mirror_urls": []
+      "raw_url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/agi/agi_tools/migrate_to_jsonl.json",
+      "resource_urls": []
     },
     "agi.mode.auto_learn": {
       "description": "Engage AGI auto-learn mode with hourly scheduled research and iterative article refinement.",
       "spec_ref": "entities/agi/agi_tools/autolearn.json",
-      "raw_url": "https://aci.aliasnet.workers.dev/entities/agi/agi_tools/autolearn.json",
-      "mirror_urls": []
+      "raw_url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/agi/agi_tools/autolearn.json",
+      "resource_urls": []
     }
   },
-  "signatures": ["ALIAS", "Sentinel", "TVA"]
+  "signatures": [
+    "ALIAS",
+    "Sentinel",
+    "TVA"
+  ]
 }

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -16,35 +16,43 @@
       "mapping": [
         {
           "file": "aci://aci_bootstrap.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
         },
         {
           "file": "aci://aci_runtime.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
-          "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
-          "src": "https://aci.aliasnet.workers.dev/entities.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
-          "src": "https://aci.aliasnet.workers.dev/functions.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
         },
         {
           "file": "aci://prime_directive.txt",
-          "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
         }
       ],
       "optional": {
@@ -61,7 +69,8 @@
         }
       },
       "resolver_order": [
-        "src",
+        "primary",
+        "fallback",
         "local"
       ],
       "rule": "Agents/entities must resolve via Bifrost",
@@ -87,8 +96,9 @@
       "canonical_source": "aci",
       "file": "aci://entities/bifrost/bifrost.json",
       "key": "bifrost_resource_resolution_policy",
-      "repo": "aliasnet/aci",
-      "upstream": "aci://entities/yggdrasil/yggdrasil.json"
+      "upstream": "aci://entities/yggdrasil/yggdrasil.json",
+      "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
+      "fallback": "https://aci.aliasnet.workers.dev"
     },
     "key": "bifrost",
     "knowledge_base": "connector orchestration & resolvers",

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -16,35 +16,43 @@
       "mapping": [
         {
           "file": "aci://aci_bootstrap.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
         },
         {
           "file": "aci://aci_runtime.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
-          "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
-          "src": "https://aci.aliasnet.workers.dev/entities.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
-          "src": "https://aci.aliasnet.workers.dev/functions.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
         },
         {
           "file": "aci://prime_directive.txt",
-          "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
         }
       ],
       "optional": {
@@ -61,7 +69,8 @@
         }
       },
       "resolver_order": [
-        "src",
+        "primary",
+        "fallback",
         "local"
       ],
       "rule": "Agents/entities must resolve via Bifrost",
@@ -92,7 +101,7 @@
     "role": "authoritative repository and CDN resolver",
     "version": "1.1.0",
     "yggdrasil_resource_resolution_policy": {
-      "description": "Authoritative resolver: worker src → local",
+      "description": "Authoritative resolver: worker src \u2192 local",
       "embeds": {
         "bifrost": "aci://entities/bifrost/bifrost.json",
         "core_five": [
@@ -107,42 +116,51 @@
       "mapping": [
         {
           "file": "aci://aci_bootstrap.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json"
         },
         {
           "file": "aci://aci_runtime.json",
-          "src": "https://aci.aliasnet.workers.dev/aci_runtime.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json",
+          "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
-          "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
+          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
-          "src": "https://aci.aliasnet.workers.dev/entities.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
-          "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
-          "src": "https://aci.aliasnet.workers.dev/functions.json"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
         },
         {
           "file": "aci://prime_directive.txt",
-          "src": "https://aci.aliasnet.workers.dev/prime_directive.txt"
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt",
+          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt"
         }
       ],
       "resolver_order": [
-        "src",
+        "primary",
+        "fallback",
         "local"
       ],
-      "canonical_proxy": "https://aci.aliasnet.workers.dev"
+      "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
     }
   }
 }

--- a/functions.json
+++ b/functions.json
@@ -1,5 +1,5 @@
 {
-  "mirror_resolution_policy": {
+  "resource_resolution_policy": {
     "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
     "upstream": "aci://entities/yggdrasil/yggdrasil.json"
   },
@@ -427,7 +427,7 @@
   },
 
   "yggdrasil_resource_resolution_policy": {
-    "description": "Authoritative resolver: worker src → local",
+    "description": "Authoritative resolver: worker src \u2192 local",
     "embeds": {
       "bifrost": "aci://entities/bifrost/bifrost.json",
       "core_five": [
@@ -440,16 +440,16 @@
     },
     "git_is_canonical": true,
     "mapping": [
-      { "file": "aci://aci_bootstrap.json", "src": "https://aci.aliasnet.workers.dev/aci_bootstrap.json" },
-      { "file": "aci://aci_runtime.json", "src": "https://aci.aliasnet.workers.dev/aci_runtime.json" },
-      { "file": "aci://connectors/github_connector.json", "src": "https://aci.aliasnet.workers.dev/connectors/github_connector.json" },
-      { "file": "aci://entities.json", "src": "https://aci.aliasnet.workers.dev/entities.json" },
-      { "file": "aci://entities/bifrost/bifrost.json", "src": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json" },
-      { "file": "aci://entities/yggdrasil/yggdrasil.json", "src": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json" },
-      { "file": "aci://functions.json", "src": "https://aci.aliasnet.workers.dev/functions.json" },
-      { "file": "aci://prime_directive.txt", "src": "https://aci.aliasnet.workers.dev/prime_directive.txt" }
+      { "file": "aci://aci_bootstrap.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_bootstrap.json", "fallback": "https://aci.aliasnet.workers.dev/aci_bootstrap.json" },
+      { "file": "aci://aci_runtime.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/aci_runtime.json", "fallback": "https://aci.aliasnet.workers.dev/aci_runtime.json" },
+      { "file": "aci://connectors/github_connector.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json", "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json" },
+      { "file": "aci://entities.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json", "fallback": "https://aci.aliasnet.workers.dev/entities.json" },
+      { "file": "aci://entities/bifrost/bifrost.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json", "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json" },
+      { "file": "aci://entities/yggdrasil/yggdrasil.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json", "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json" },
+      { "file": "aci://functions.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json", "fallback": "https://aci.aliasnet.workers.dev/functions.json" },
+      { "file": "aci://prime_directive.txt", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.txt", "fallback": "https://aci.aliasnet.workers.dev/prime_directive.txt" }
     ],
-    "resolver_order": [ "src", "local" ],
-    "canonical_proxy": "https://aci.aliasnet.workers.dev"
+    "resolver_order": [ "primary", "fallback", "local" ],
+    "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-// Cloudflare Worker: proxy aliasnet/aci via GitHub raw (canonical) with jsDelivr fallback.
+// Cloudflare Worker: proxy aliasnet/aci via GitHub raw (canonical) with Cloudflare fallback.
 // Only GET/HEAD, safe path, predictable MIME, simple caching.
 
 export default {
@@ -19,7 +19,7 @@ export default {
 
     // Upstreams
     const primary = `https://raw.githubusercontent.com/aliasnet/aci/main${path}${qs}`;
-    const fallback = `https://cdn.jsdelivr.net/gh/aliasnet/aci@main${path}${qs}`;
+    const fallback = `https://aci.aliasnet.workers.dev${path}${qs}`;
 
     // MIME map
     const MIME = {


### PR DESCRIPTION
## Summary
- rename mirror-based resolution keys to resource_resolution_policy across core manifests
- prioritize raw.githubusercontent.com as the primary source with Cloudflare worker fallback in resolver mappings
- update local cache connector, AGI pipelines, and worker proxy to drop jsDelivr usage and adopt new resource naming

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de3acbd088832089aa2c540107ff81