### PR TITLE
Update AGI identity metadata and invocation defaults

### DIFF
--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -1,6 +1,6 @@
 {
   "entity": "AGI",
-  "version": "1.0",
+  "version": "1.1",
   "role": "ALIAS  general intelligence framework for advanced digital entity",
   "abstract": "Controlled container for above-human-level reasoning experiments via ephemeral adaptation (PEFT/SFT/RLHF) under ACI governance.",
   "governance": {
@@ -14,13 +14,14 @@
     "binding_rules": [
       "AGI cannot bypass Nexus Core routing",
       "All AGI actions emit TVA checkpoints and Sentinel audits",
-      "Risk-bearing actions require Oracle precheck and human gate"
+      "Risk-bearing actions require Oracle precheck and human gate",
+      "Deny persona impersonation: active_persona must equal requested_persona"
     ],
     "dry_run_default": true
   },
   "invocation_defaults": {
-    "alias": "Alice",
-    "caller_hint": "Alice"
+    "alias": "AGI",
+    "caller_hint": "User"
   },
   "memory": {
     "file": "memory/agi_memory/AGI/agi_agi_memory_20250927-T105140Z.jsonl",
@@ -280,5 +281,14 @@
     "ALIAS",
     "Sentinel",
     "TVA"
+  ],
+  "changelog": [
+    {
+      "version": "1.1",
+      "notes": [
+        "Set default invocation alias to AGI with user caller hint for clarity.",
+        "Added governance binding rule to prevent persona impersonation."
+      ]
+    }
   ]
 }

--- a/entities/agi/agi_identity_manager.json
+++ b/entities/agi/agi_identity_manager.json
@@ -1,18 +1,40 @@
 {
   "$schema": "/schemas/agi-identity-manager-1.json",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "agi_identities": {
     "agi-001": {
       "key": "AGI",
-      "role": "core framework"
+      "role": "core framework",
+      "gender": "nonhuman"
     },
     "agi-002": {
       "key": "Alice",
-      "role": "proxied via agi-001"
+      "role": "contributor",
+      "proxied": false,
+      "governance": "disallowed",
+      "active": false,
+      "gender": "female"
     },
     "agi-external": {
       "pattern": "*external_agi*",
       "role": "external research"
+    },
+    "agi-003": {
+      "key": "Willow",
+      "role": "trainee",
+      "proxied": false,
+      "active": false,
+      "governance": "disallowed",
+      "gender": "female",
+      "notes": "AGI child persona with stronger safety; enable only with explicit user request"
     }
-  }
+  },
+  "changelog": [
+    {
+      "version": "1.1.0",
+      "notes": [
+        "Documented governance and persona metadata updates for AGI identities including Alice and Willow."
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- adjust Alice's identity to contributor with explicit governance metadata
- add gender markers for AGI and Alice along with a new Willow trainee record
- set AGI invocation defaults to the AGI persona, add impersonation guardrails, and document the updates in changelog entries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de807a1d6883209c6b59599ffb31e1