### PR TITLE
Add identity rules to ALIAS registry configuration

### DIFF
--- a/alias.json
+++ b/alias.json
@@ -42,6 +42,17 @@
       "sentinel": "safeguards privacy, survival, and stability",
       "tva": "enforces anomaly control and runtime authority",
       "mother": "serves as governance interface"
+    },
+    "identity_rules": {
+      "case_sensitive": true,
+      "protected_names": [
+        "ALIAS"
+      ],
+      "deny_persona_as_root": [
+        "AGI",
+        "Alice",
+        "Willow"
+      ]
     }
   },
   "resource_resolution_policy": {


### PR DESCRIPTION
## Summary
- add identity rules to the alias registry to enforce case-sensitive identity checks
- protect the ALIAS root name and deny AGI, Alice, and Willow from assuming root personas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8390bf548320bea48f9d04a361ed