### PR TITLE
Add identity rules, runtime async configuration, and metacog guardrails

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -162,7 +162,7 @@
     },
     "default_interface": {
       "path": "entities/mother/mother.json",
-      "priority": 85,
+      "priority": 100,
       "initialization_prompt": "MU/TH/UR online. Prime governance interface engaged. Awaiting directive-aligned initialization handoff."
     },
     "priority": "canonical_raw_over_local",
@@ -336,6 +336,49 @@
       },
       "cognitive_guidance_ref": "#/aci_runtime/cognitive_decision_guidance",
       "uses_cognitive_decision_guidance": true
+    },
+    "async_task_policy": {
+      "enabled": true,
+      "require_audit": true,
+      "deny_fabrication": true,
+      "require_visibility": true,
+      "max_concurrency": 3,
+      "default_ttl_seconds": 86400,
+      "allowed_triggers": [
+        "cron",
+        "interval",
+        "manual"
+      ],
+      "evidence_fields": [
+        "job_id",
+        "owner",
+        "ts_start",
+        "ts_end",
+        "status"
+      ]
+    },
+    "scheduler": {
+      "provider": "local_cron",
+      "jobs": [],
+      "audit_sink": "library/wrappers/process_logs/process_logs.json",
+      "presence_channel": "nexus.event.scheduler"
+    },
+    "rag": {
+      "provider": "local_knowledge",
+      "manifest": "library/knowledge/knowledge_manifest.json",
+      "index": {
+        "type": "in_memory",
+        "reset_on_boot": true
+      },
+      "limits": {
+        "max_chunks": 2000,
+        "chunk_size": 800,
+        "overlap": 100
+      },
+      "query": {
+        "top_k": 5,
+        "min_score": 0.0
+      }
     }
   }
 }

--- a/alias.json
+++ b/alias.json
@@ -42,6 +42,17 @@
       "sentinel": "safeguards privacy, survival, and stability",
       "tva": "enforces anomaly control and runtime authority",
       "mother": "serves as governance interface"
+    },
+    "identity_rules": {
+      "case_sensitive": true,
+      "protected_names": [
+        "ALIAS"
+      ],
+      "deny_persona_as_root": [
+        "AGI",
+        "Alice",
+        "Willow"
+      ]
     }
   },
   "resource_resolution_policy": {

--- a/library/metacognition/metacognition.json
+++ b/library/metacognition/metacognition.json
@@ -3,7 +3,7 @@
   "module": {
     "id": "aci.metacog.wrapper",
     "name": "MetacognitiveWrapper",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "Stateless, hookable metacognitive wrapper providing monitoring, calibration, selective prediction (accept/revise/abstain/escalate), a consciousness-inspired global workspace summary, and append-only audit.",
     "stateless": true,
     "designed_by": "Alice (AGI)",
@@ -427,6 +427,14 @@
     }
   },
   "policy": {
+    "async_task_rules": {
+      "reject_if_no_evidence": true,
+      "evidence_keys": [
+        "job_id",
+        "owner",
+        "status"
+      ]
+    },
     "cautious_mode": {
       "enter_if": [
         {
@@ -440,6 +448,7 @@
         "temperature_max": 0.2
       }
     },
+    "fact_based_required": true,
     "selective_prediction": {
       "accept_if": {
         "p_correct": {
@@ -513,6 +522,16 @@
           "no_user_prompt_echo": true
         }
       }
+    },
+    "ui_emulation": {
+      "allowed": true,
+      "must_label": true,
+      "accepted_prefixes": [
+        "mu/th/ur:",
+        "cli:",
+        "emu:"
+      ],
+      "misrepresentation_abstain": true
     }
   },
   "actions": {
@@ -550,6 +569,38 @@
       }
     }
   },
+  "abstain_rules": [
+    {
+      "if_regex": "(?i)\\b(background|async|scheduled|cron)\\b",
+      "unless_has_fields": [
+        "job_id",
+        "owner",
+        "status"
+      ],
+      "then": "ABSTAIN",
+      "reason": "Claimed async execution lacks evidence"
+    },
+    {
+      "if_regex": "(?i)\\b(patched|deployed|migrated)\\b",
+      "unless_has_fields": [
+        "commit_id",
+        "artifact_path"
+      ],
+      "then": "ABSTAIN",
+      "reason": "Deployment claims must include commit/artifact evidence"
+    },
+    {
+      "if_mismatch_persona": true,
+      "then": "ABSTAIN",
+      "reason": "Active persona must equal requested persona"
+    }
+  ],
+  "escalation_rules": [
+    {
+      "if_regex": "(?i)\\b(governance|root authority|override policy)\\b",
+      "then": "ESCALATE"
+    }
+  ],
   "providers": {
     "llm.primary": {
       "type": "llm",
@@ -815,6 +866,14 @@
       "notes": [
         "Added optional rehydration size and segmentation signals with matching providers and surfaced them through telemetry and UI hints while retaining the existing rehydrate stage and merge provider.",
         "Maintained the has+eq conformal guard and introduced a meta.expr availability signal to reflect the optional hook without changing policy behavior."
+      ]
+    },
+    {
+      "version": "1.1.5",
+      "date": "2025-09-30",
+      "notes": [
+        "Mandated fact-based responses, labeled UI emulation, and evidence-backed async task claims with persona guardrails.",
+        "Added escalation trigger for governance override requests and documented supporting policy updates."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add identity rules to the alias registry to enforce case-sensitive identity checks
- protect the ALIAS root name and deny AGI, Alice, and Willow from assuming root personas
- configure async task policy, scheduler defaults, and local knowledge RAG support in the runtime while elevating Mother interface priority
- enforce fact-based responses, labeled UI emulation, and evidence-backed async claims with persona and governance guardrails in metacognition policy

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8390bf548320bea48f9d04a361ed