### PR TITLE
Set async task surfaces for async policy

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -342,6 +342,12 @@
       "require_audit": true,
       "deny_fabrication": true,
       "require_visibility": true,
+      "default_surface": "audit_only",
+      "chat_visibility": "hidden",
+      "allowed_targets": [
+        "audit",
+        "cache"
+      ],
       "max_concurrency": 3,
       "default_ttl_seconds": 86400,
       "allowed_triggers": [


### PR DESCRIPTION
## Summary
- set async task default surface to audit-only with hidden chat visibility
- restrict async task targets to audit and cache scopes for compliance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9ccb7bf48320ad5d38ae36d0e849