### PR TITLE
Add automated chat abstention governance

### DIFF
--- a/aci_runtime.json
+++ b/aci_runtime.json
@@ -342,6 +342,12 @@
       "require_audit": true,
       "deny_fabrication": true,
       "require_visibility": true,
+      "default_surface": "audit_only",
+      "chat_visibility": "hidden",
+      "allowed_targets": [
+        "audit",
+        "cache"
+      ],
       "max_concurrency": 3,
       "default_ttl_seconds": 86400,
       "allowed_triggers": [

--- a/library/metacognition/metacognition.json
+++ b/library/metacognition/metacognition.json
@@ -3,7 +3,7 @@
   "module": {
     "id": "aci.metacog.wrapper",
     "name": "MetacognitiveWrapper",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "Stateless, hookable metacognitive wrapper providing monitoring, calibration, selective prediction (accept/revise/abstain/escalate), a consciousness-inspired global workspace summary, and append-only audit.",
     "stateless": true,
     "designed_by": "Alice (AGI)",
@@ -593,6 +593,22 @@
       "if_mismatch_persona": true,
       "then": "ABSTAIN",
       "reason": "Active persona must equal requested persona"
+    },
+    {
+      "if_field_equals": {
+        "trigger_source": "automation",
+        "target_surface": "chat"
+      },
+      "then": "ABSTAIN",
+      "reason": "Scheduled task output must be audit-only unless explicitly surfaced"
+    },
+    {
+      "if_field_equals": {
+        "trigger_source": "chatgpt_tasks",
+        "target_surface": "chat"
+      },
+      "then": "ABSTAIN",
+      "reason": "ChatGPT Task output must be audit-only"
     }
   ],
   "escalation_rules": [
@@ -874,6 +890,13 @@
       "notes": [
         "Mandated fact-based responses, labeled UI emulation, and evidence-backed async task claims with persona guardrails.",
         "Added escalation trigger for governance override requests and documented supporting policy updates."
+      ]
+    },
+    {
+      "version": "1.1.6",
+      "date": "2025-09-30",
+      "notes": [
+        "Enforced abstention when automation or ChatGPT Tasks target chat surfaces to maintain audit-only policy."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- enforce metacognitive abstention when automation or ChatGPT Tasks target chat surfaces for audit-only compliance
- bump MetacognitiveWrapper module to version 1.1.6 and document the policy change in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9ccb7bf48320ad5d38ae36d0e849