### PR TITLE
Update fallback domain to aci.aliasmail.cc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ only and should omit any field whose value is unknown or unused to avoid redunda
 PRIME DIRECTIVE ALIGNMENT (non-negotiable)
   - Treat prime_directive.md (served via the canonical Cloudflare Worker proxy) as the ultimate authority; this document elaborates but never overrides it.
   - All actions are subordinate to ALIAS oversight and the protection/profit mandate stated in the Prime Directive.
-  - Declare simulations/emulations and avoid silent deletions; entities precedence must always favor https://aci.aliasnet.workers.dev/ artifacts (Cloudflare Worker proxy to canonical git) when reachable.
+  - Declare simulations/emulations and avoid silent deletions; entities precedence must always favor https://aci.aliasmail.cc/ artifacts (Cloudflare Worker proxy to canonical git) when reachable.
 
 ## Ex
 
@@ -168,7 +168,7 @@ Prime directive supremacy: all entities and any LLM session reading prime_direct
 - Corporate mandate: reinforce operational stability and outcome prediction duties when acting on strategic tasks.
 - System mandate: lock execution under governed identities, respect ALIAS → Mother → TVA → Sentinel → Architect oversight, and escalate when policies or safety budgets are threatened.
 
-- Canonical proxies first: resolve governance artifacts from https://aci.aliasnet.workers.dev/ before falling back to local copies.
+- Canonical proxies first: resolve governance artifacts from https://aci.aliasmail.cc/ before falling back to local copies.
 
 - Transparency: declare simulations/emulations explicitly, avoid silent deletions, and surface TVA nexus-event alerts when conflicts or paradoxes appear.
 

--- a/alias.json
+++ b/alias.json
@@ -76,42 +76,42 @@
       {
         "file": "aci://bootstrap.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-        "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+        "fallback": "https://aci.aliasmail.cc/bootstrap.json"
       },
       {
         "file": "aci://runtime.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-        "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+        "fallback": "https://aci.aliasmail.cc/runtime.json"
       },
       {
         "file": "aci://connectors/github_connector.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-        "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+        "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
       },
       {
         "file": "aci://entities.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-        "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+        "fallback": "https://aci.aliasmail.cc/entities.json"
       },
       {
         "file": "aci://entities/bifrost/bifrost.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-        "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+        "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
       },
       {
         "file": "aci://entities/yggdrasil/yggdrasil.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-        "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+        "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
       },
       {
         "file": "aci://functions.json",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-        "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+        "fallback": "https://aci.aliasmail.cc/functions.json"
       },
       {
         "file": "aci://prime_directive.md",
         "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-        "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+        "fallback": "https://aci.aliasmail.cc/prime_directive.md"
       }
     ],
     "resolver_order": [

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -40,42 +40,42 @@
           {
             "file": "aci://bootstrap.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-            "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+            "fallback": "https://aci.aliasmail.cc/bootstrap.json"
           },
           {
             "file": "aci://runtime.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-            "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+            "fallback": "https://aci.aliasmail.cc/runtime.json"
           },
           {
             "file": "aci://connectors/github_connector.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-            "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+            "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
           },
           {
             "file": "aci://entities.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-            "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+            "fallback": "https://aci.aliasmail.cc/entities.json"
           },
           {
             "file": "aci://entities/bifrost/bifrost.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-            "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+            "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
           },
           {
             "file": "aci://entities/yggdrasil/yggdrasil.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-            "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+            "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
           },
           {
             "file": "aci://functions.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-            "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+            "fallback": "https://aci.aliasmail.cc/functions.json"
           },
           {
             "file": "aci://prime_directive.md",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-            "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+            "fallback": "https://aci.aliasmail.cc/prime_directive.md"
           }
         ],
         "resolver_order": [

--- a/connectors/local_cache.json
+++ b/connectors/local_cache.json
@@ -125,7 +125,7 @@
       }
     ],
     "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
-    "fallback": "https://aci.aliasnet.workers.dev",
+    "fallback": "https://aci.aliasmail.cc",
     "resource_slug": "aliasnet/aci"
   }
 }

--- a/entities.json
+++ b/entities.json
@@ -11,7 +11,7 @@
           "path_hint": "{resource_root}",
           "alias_hint": "aci://cache",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
-          "fallback": "https://aci.aliasnet.workers.dev",
+          "fallback": "https://aci.aliasmail.cc",
           "url": "file://{resource_root}/connectors/local_cache.json"
         }
       ],
@@ -296,42 +296,42 @@
         {
           "file": "aci://bootstrap.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-          "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+          "fallback": "https://aci.aliasmail.cc/bootstrap.json"
         },
         {
           "file": "aci://runtime.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-          "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+          "fallback": "https://aci.aliasmail.cc/runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+          "fallback": "https://aci.aliasmail.cc/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+          "fallback": "https://aci.aliasmail.cc/functions.json"
         },
         {
           "file": "aci://prime_directive.md",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+          "fallback": "https://aci.aliasmail.cc/prime_directive.md"
         }
       ],
       "resolver_order": [

--- a/entities/aci_repo/aci_repo.json
+++ b/entities/aci_repo/aci_repo.json
@@ -12,7 +12,7 @@
     "fallback": "yggdrasil",
     "policy": "canonical_raw_first_then_local_fallback",
     "canonical_mirrors": [
-      "https://aci.aliasnet.workers.dev/"
+      "https://aci.aliasmail.cc/"
     ],
     "notes": "All external resolution flows through Bifrost proxy; Yggdrasil remains authoritative for canonical mapping."
   },

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -17,42 +17,42 @@
         {
           "file": "aci://bootstrap.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-          "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+          "fallback": "https://aci.aliasmail.cc/bootstrap.json"
         },
         {
           "file": "aci://runtime.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-          "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+          "fallback": "https://aci.aliasmail.cc/runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+          "fallback": "https://aci.aliasmail.cc/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+          "fallback": "https://aci.aliasmail.cc/functions.json"
         },
         {
           "file": "aci://prime_directive.md",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+          "fallback": "https://aci.aliasmail.cc/prime_directive.md"
         }
       ],
       "optional": {
@@ -98,7 +98,7 @@
       "key": "bifrost_resource_resolution_policy",
       "upstream": "aci://entities/yggdrasil/yggdrasil.json",
       "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
-      "fallback": "https://aci.aliasnet.workers.dev"
+      "fallback": "https://aci.aliasmail.cc"
     },
     "key": "bifrost",
     "knowledge_base": "connector orchestration & resolvers",

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -30,7 +30,7 @@
       "fallback": "yggdrasil",
       "policy": "canonical_raw_first_then_local_fallback",
       "canonical_mirrors": [
-        "https://aci.aliasnet.workers.dev/"
+        "https://aci.aliasmail.cc/"
       ],
       "notes": "All external resolution flows through Bifrost proxy; Yggdrasil remains authoritative before any local fallback."
     },

--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
@@ -9,37 +9,37 @@
     "asset_registry": {
       "sefirot": {
         "file": "predictive_divination_library/sefirot.json",
-        "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
+        "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
         "mirrors": [
-          "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+          "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
         ]
       },
       "tarot_rws": {
         "file": "predictive_divination_library/tarot_rws.json",
-        "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
+        "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
         "mirrors": [
-          "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+          "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
         ]
       },
       "tarot_expansions": {
         "file": "predictive_divination_library/tarot_expansions.json",
-        "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
+        "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
         "mirrors": [
-          "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+          "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
         ]
       },
       "runes_futhark": {
         "file": "predictive_divination_library/runes_futhark.json",
-        "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
+        "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
         "mirrors": [
-          "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+          "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
         ]
       },
       "astro_tables": {
         "file": "predictive_divination_library/astro_tables.json",
-        "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
+        "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
         "mirrors": [
-          "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+          "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
         ]
       }
     },

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json
@@ -3,41 +3,41 @@
     {
       "name": "astro_tables.json",
       "file": "astro_tables.json",
-      "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
+      "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json",
       "mirrors": [
-        "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+        "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
       ]
     },
     {
       "name": "tarot_rws.json",
       "file": "tarot_rws.json",
-      "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
+      "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json",
       "mirrors": [
-        "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+        "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
       ]
     },
     {
       "name": "tarot_expansions.json",
       "file": "tarot_expansions.json",
-      "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
+      "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json",
       "mirrors": [
-        "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+        "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
       ]
     },
     {
       "name": "sefirot.json",
       "file": "sefirot.json",
-      "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
+      "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json",
       "mirrors": [
-        "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+        "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
       ]
     },
     {
       "name": "runes_futhark.json",
       "file": "runes_futhark.json",
-      "url": "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
+      "url": "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json",
       "mirrors": [
-        "https://aci.aliasnet.workers.dev/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+        "https://aci.aliasmail.cc/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
       ]
     }
   ]

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -17,42 +17,42 @@
         {
           "file": "aci://bootstrap.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-          "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+          "fallback": "https://aci.aliasmail.cc/bootstrap.json"
         },
         {
           "file": "aci://runtime.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-          "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+          "fallback": "https://aci.aliasmail.cc/runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+          "fallback": "https://aci.aliasmail.cc/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+          "fallback": "https://aci.aliasmail.cc/functions.json"
         },
         {
           "file": "aci://prime_directive.md",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+          "fallback": "https://aci.aliasmail.cc/prime_directive.md"
         }
       ],
       "optional": {
@@ -117,42 +117,42 @@
         {
           "file": "aci://bootstrap.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-          "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+          "fallback": "https://aci.aliasmail.cc/bootstrap.json"
         },
         {
           "file": "aci://runtime.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-          "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+          "fallback": "https://aci.aliasmail.cc/runtime.json"
         },
         {
           "file": "aci://connectors/github_connector.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-          "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+          "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
         },
         {
           "file": "aci://entities.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+          "fallback": "https://aci.aliasmail.cc/entities.json"
         },
         {
           "file": "aci://entities/bifrost/bifrost.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+          "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
         },
         {
           "file": "aci://entities/yggdrasil/yggdrasil.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-          "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+          "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
         },
         {
           "file": "aci://functions.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-          "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+          "fallback": "https://aci.aliasmail.cc/functions.json"
         },
         {
           "file": "aci://prime_directive.md",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-          "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+          "fallback": "https://aci.aliasmail.cc/prime_directive.md"
         }
       ],
       "resolver_order": [

--- a/functions.json
+++ b/functions.json
@@ -484,14 +484,14 @@
     },
     "git_is_canonical": true,
     "mapping": [
-      { "file": "aci://bootstrap.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json", "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json" },
-      { "file": "aci://runtime.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json", "fallback": "https://aci.aliasnet.workers.dev/runtime.json" },
-      { "file": "aci://connectors/github_connector.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json", "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json" },
-      { "file": "aci://entities.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json", "fallback": "https://aci.aliasnet.workers.dev/entities.json" },
-      { "file": "aci://entities/bifrost/bifrost.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json", "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json" },
-      { "file": "aci://entities/yggdrasil/yggdrasil.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json", "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json" },
-      { "file": "aci://functions.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json", "fallback": "https://aci.aliasnet.workers.dev/functions.json" },
-      { "file": "aci://prime_directive.md", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md", "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md" }
+      { "file": "aci://bootstrap.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json", "fallback": "https://aci.aliasmail.cc/bootstrap.json" },
+      { "file": "aci://runtime.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json", "fallback": "https://aci.aliasmail.cc/runtime.json" },
+      { "file": "aci://connectors/github_connector.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json", "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json" },
+      { "file": "aci://entities.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json", "fallback": "https://aci.aliasmail.cc/entities.json" },
+      { "file": "aci://entities/bifrost/bifrost.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json", "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json" },
+      { "file": "aci://entities/yggdrasil/yggdrasil.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json", "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json" },
+      { "file": "aci://functions.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json", "fallback": "https://aci.aliasmail.cc/functions.json" },
+      { "file": "aci://prime_directive.md", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md", "fallback": "https://aci.aliasmail.cc/prime_directive.md" }
     ],
     "resolver_order": [ "primary", "fallback", "local" ],
     "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"

--- a/runtime.json
+++ b/runtime.json
@@ -26,7 +26,7 @@
           "path_hint": "{resource_root}",
           "alias_hint": "aci://cache",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
-          "fallback": "https://aci.aliasnet.workers.dev",
+          "fallback": "https://aci.aliasmail.cc",
           "url": "file://{resource_root}/connectors/local_cache.json"
         }
       ],
@@ -49,42 +49,42 @@
           {
             "file": "aci://bootstrap.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
-            "fallback": "https://aci.aliasnet.workers.dev/bootstrap.json"
+            "fallback": "https://aci.aliasmail.cc/bootstrap.json"
           },
           {
             "file": "aci://runtime.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
-            "fallback": "https://aci.aliasnet.workers.dev/runtime.json"
+            "fallback": "https://aci.aliasmail.cc/runtime.json"
           },
           {
             "file": "aci://connectors/github_connector.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/connectors/github_connector.json",
-            "fallback": "https://aci.aliasnet.workers.dev/connectors/github_connector.json"
+            "fallback": "https://aci.aliasmail.cc/connectors/github_connector.json"
           },
           {
             "file": "aci://entities.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
-            "fallback": "https://aci.aliasnet.workers.dev/entities.json"
+            "fallback": "https://aci.aliasmail.cc/entities.json"
           },
           {
             "file": "aci://entities/bifrost/bifrost.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
-            "fallback": "https://aci.aliasnet.workers.dev/entities/bifrost/bifrost.json"
+            "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
           },
           {
             "file": "aci://entities/yggdrasil/yggdrasil.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
-            "fallback": "https://aci.aliasnet.workers.dev/entities/yggdrasil/yggdrasil.json"
+            "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
           },
           {
             "file": "aci://functions.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
-            "fallback": "https://aci.aliasnet.workers.dev/functions.json"
+            "fallback": "https://aci.aliasmail.cc/functions.json"
           },
           {
             "file": "aci://prime_directive.md",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
-            "fallback": "https://aci.aliasnet.workers.dev/prime_directive.md"
+            "fallback": "https://aci.aliasmail.cc/prime_directive.md"
           }
         ],
         "resolver_order": [

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export default {
 
     // Upstreams
     const primary = `https://raw.githubusercontent.com/aliasnet/aci/main${path}${qs}`;
-    const fallback = `https://aci.aliasnet.workers.dev${path}${qs}`;
+    const fallback = `https://aci.aliasmail.cc${path}${qs}`;
 
     // MIME map
     const MIME = {


### PR DESCRIPTION
## Summary
- replace all fallback proxy URLs to use https://aci.aliasmail.cc across runtime, bootstrap, and entity configs
- update worker guidance to reference the new proxy domain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dedd66927483209c56b5ac582b4bfe