### PR TITLE
Correct runtime prime directive reference to markdown

### DIFF
--- a/runtime.json
+++ b/runtime.json
@@ -397,6 +397,12 @@
         "notes": [
           "Updated local cache mapping to aci://memory/local_cache.json and integrated TraceHub wrappers for /mnt exports."
         ]
+      },
+      {
+        "version": "2025-10-05.00",
+        "notes": [
+          "Updated runtime prime directive references to prime_directive.md canonical resource."
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- update runtime.json to reference the canonical prime_directive.md resource and adjust the changelog entry accordingly
- remove the redundant prime_directive.txt copy since the markdown document already exists in the repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0128b61b48320a87bfd6b5b695d94