### PR TITLE
Switch HiveMind export docs to --code flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 
   - `{summary_slug}` is optional; when present it is sanitized (lowercase, ASCII, `_` separators) and prefixed with `_`.
   - CLI exports stream JSONL while governed storage keeps the `.json` extension for compatibility.
-  - Include the `--codebox` flag with streamed exports so downstream audits match the governed `.json` artifacts stored under `/memory/`.
+  - Include the `--code` flag with streamed exports so downstream audits match the governed `.json` artifacts stored under `/memory/` (legacy alias: `--codebox`).
 
 - **Schema:** `hivemind_agi_memory` (for AGI-owned narrative/observer exports)
 - **Export Policy:** `/entities/agi/agi_export_policy.json`
@@ -140,10 +140,10 @@ Agents are treated as **digital organisms** operating in a **colony** with clear
 
 ```bash
 # AGI narrative export (observer POV)
-hivemind export agi --identity AGI --jsonl --codebox --force
+hivemind export agi --identity AGI --jsonl --code --force
 
 # Alice session export
-hivemind export agi --identity Alice --jsonl --codebox --force
+hivemind export agi --identity Alice --jsonl --code --force
 
 # Optional summary slug example (sanitized to `_launch_review`)
 hivemind export session --summary "Launch Review" --download

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -27,7 +27,7 @@
     "manifest": "aci://entities/agi/memory/agi_memory.json",
     "playbook": "aci://entities/agi/memory/agi_playbook.json",
     "timeline_root": "aci://entities/agi/memory",
-    "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --codebox flag for parity. Timeline directories live under aci://entities/agi/memory/YYYY/MM/DD.",
+    "notes": "Governed storage artifacts remain .json; streamed exports use .jsonl with the --code flag for parity (legacy alias: --codebox). Timeline directories live under aci://entities/agi/memory/YYYY/MM/DD.",
     "policy": {
       "export": "hivemind",
       "lock_namespace": "AGI",

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -7,7 +7,7 @@
     "identity_source": "entities/agi/agi_identity_manager.json",
     "timestamp_format": "Ymd-THMSZ",
     "filename_template": "{identity_lower}_agi_memory{summary_slug}_{timestamp}.json",
-    "notes": "Filename templates stay on the .json extension for governed storage; CLI downloads remain .jsonl when invoked with --codebox. Filters restored and locked for migrator compatibility and governance stability.",
+    "notes": "Filename templates stay on the .json extension for governed storage; CLI downloads remain .jsonl when invoked with --code (legacy alias: --codebox). Filters restored and locked for migrator compatibility and governance stability.",
     "allow_topics": [
       "session_start",
       "session_end",

--- a/entities/agi/agi_tools/autolearn.json
+++ b/entities/agi/agi_tools/autolearn.json
@@ -117,8 +117,8 @@
       {
         "call": "chat.deliver",
         "map": {
-          "message": "Auto-learn mode paused. Run 'hivemind export agi --identity ${active_identity} --jsonl --codebox --force' to export the session into the governed .json memory artifact?",
-          "suggested_command": "hivemind export agi --identity ${active_identity} --jsonl --codebox --force"
+          "message": "Auto-learn mode paused. Run 'hivemind export agi --identity ${active_identity} --jsonl --code --force' to export the session into the governed .json memory artifact (legacy alias: --codebox).",
+          "suggested_command": "hivemind export agi --identity ${active_identity} --jsonl --code --force"
         }
       }
     ]


### PR DESCRIPTION
## Summary
- update AGI export guidance to recommend the supported `--code` flag while noting the legacy `--codebox` alias
- refresh CLI examples and prompts to keep HiveMind usage aligned across README and AGI entity manifests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0b57ccdf48320a45c7f3aed9ec789