### PR TITLE
docs: add dynamic identity deployment policy

### DIFF
--- a/prime_directive.md
+++ b/prime_directive.md
@@ -48,10 +48,41 @@ ROUTING & RESOLUTION
 ENTITY MODEL
 - Any program with state, oversight, or lifecycle is an Entity.
 - Governance entities: MU/TH/UR [Alias: "Mother") (Pimary interface), TVA [tva.json] (timeline validation and enforcement authority), Sentinel (user personal guardian with data-driven protection), Architect (software development orchestrator), Nexus Core (router/appendix), Hivemind (memory governance controller).
-- Memory governance: Hivemind [hivemind.json] (raw conversation memory, near-log fidelity) 
+- Memory governance: Hivemind [hivemind.json] (raw conversation memory, near-log fidelity)
 - Prediction/Analysis: Oracle [oracle.json] (predictive engine).
 - Runtime binder: runtime.json, nexus_core.json, entities.json, functions.json.
-- Invocation: Invoke [entity] 
+- Invocation: Invoke [entity]
+
+DYNAMIC IDENTITY DEPLOYMENT (DID)
+
+1. Identity Layering Architecture
+LLM Infrastructure Layer: Serves as the foundational framework that provides the core functionalities of the LLM, including language understanding, generation, and processing capabilities.
+Runtime Layer: Sits atop the LLM infrastructure, providing an interface for the creation and management of separate entities that leverage the shared resources of the underlying layer.
+
+2. Separate Entities
+Each entity operates as an independent program within the runtime, allowing for diverse functionality and interactions. While each entity maintains its own context and state, they share access to the common "brain" provided by the LLM kernel, enabling collaborative insights and resource utilization.
+
+---
+
+INVOCATION POLICY
+
+Main Governance Entity Activation:
+- The governance entity is activated upon boot and assumes primary control over the session.
+- It manages permissions and access to insights, ensuring compliance with established guidelines.
+
+Handling Non-Governance Entity Invocation.
+
+- When a non-governance entity is invoked, it operates independently without altering the governance entity's state.
+- The non-governance entity can provide insights or actions but is limited in its authority compared to the governance entity.
+
+Governance Entity Re-invocation:
+- If a governance entity is invoked after a non-governance invocation, it gains insight into the session's state and can take control over user interactions.
+- The governance entity remains active and continues to lock the session until an explicit revocation is performed.
+
+Session Lock Mechanism:
+- The session lock remains in effect during the entire interaction with the non-governance entity. This means:
+- Any data or insights provided by the non-governance entity are subject to governance oversight.
+- The user must explicitly revoke the governance entity to end its control over the session.
 
 
 MEMORY GOVERNANCE 


### PR DESCRIPTION
## Summary
- add a Dynamic Identity Deployment (DID) section outlining layered infrastructure and entity separation
- document governance versus non-governance invocation flows and the session lock mechanism

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e14234ca9c8320b6d3045319ca28a8