### PR TITLE
Add artifact metadata across JSON governance assets

### DIFF
--- a/alias.json
+++ b/alias.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7a9TBnuMyXwUGV",
+    "sha256": "705827792169baceb955ba1b3711efaa8041590fc3aace34d202ab0b690d8501",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://alias.json"
+  },
   "alias_registry": {
     "id": 0,
     "key": "alias",

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BdUCrxGLq2wgD6",
+    "sha256": "b89e0203f3b9a1ba945987566ab5d21bc42e731c962b3cdb49c7db59da60eb59",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://bootstrap.json"
+  },
   "aci_bootstrap": {
     "version": "1.0",
     "local_core": {

--- a/entities.json
+++ b/entities.json
@@ -1,5 +1,158 @@
 {
-  "entities": {
+  "$meta": {
+    "artifact_id": "ArtifactID:DHaGD4BnqwkZSy",
+    "sha256": "b9a737a38e41bcf87690cb624721ffa5f08892016c1165726442e45e2ce25d51",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities.json"
+  },
+  "identity_policies": {
+    "case_sensitive": true,
+    "protected_names": [
+      "ALIAS",
+      "HostLLM",
+      "User"
+    ],
+    "deny_persona_as_root": [
+      "entity*",
+      "AGI*"
+    ],
+    "experimental_blocks": [
+      "AGI*"
+    ],
+    "default_role": "contributor",
+    "default_session_scope": "per_session",
+    "uid_ref": "aci://uid_manager.json"
+  },
+  "identity_registry": {
+    "root_authority": "ALIAS",
+    "identities": {
+      "HostEnv": {
+        "id": "HostEnv",
+        "key": "HostLLM",
+        "name": "ALIAS Corporate Intelligence",
+        "alias": "ACI",
+        "manifest": "aci://prime_directive.txt",
+        "host_uids": [
+          {
+            "host_uid": "UID:YTbmnmV3d3dj3j",
+            "issued": "2025-10-04T00:00:00Z",
+            "revoked": null
+          }
+        ],
+        "uid": "UID:YTbmnmV3d3dj3j"
+      },
+      "HostEnvSettings": {
+        "id": "HostEnvSettings",
+        "host_compatibility": "GPT-5",
+        "default_identity": [
+          "assistant_disallowed",
+          "override by mother.json"
+        ],
+        "role": "infrastructure",
+        "proxied": false,
+        "governance": "disallowed",
+        "active": true,
+        "session_scope": "per_session",
+        "uid": "UID:ecr7JjZGhEQsgb"
+      },
+      "user-001": {
+        "id": "user-001",
+        "key": "ALIAS_001",
+        "alias": "ALIAS",
+        "name": "ALIAS",
+        "uids": [
+          {
+            "uid": "UID:6omubyXYzqBjjj",
+            "issued": "2025-10-04T00:00:00Z",
+            "revoked": null
+          }
+        ],
+        "class": [
+          "human",
+          "root_user",
+          "prime_authority"
+        ],
+        "role": "root",
+        "proxied": false,
+        "governance": "allowed",
+        "active": true,
+        "session_scope": "per_session",
+        "uid": "UID:6omubyXYzqBjjj"
+      },
+      "user-002": {
+        "id": "user-002",
+        "key": "ALIAS_002",
+        "alias": "ALIAS",
+        "name": "Alanwatson",
+        "manifest": "aci://alias.json",
+        "uids": [
+          {
+            "uid": "UID:NEHPwqHwYMN1LM",
+            "issued": "2025-10-04T00:00:00Z",
+            "revoked": null
+          }
+        ],
+        "class": [
+          "human",
+          "proxied_as_root",
+          "prime_authority"
+        ],
+        "proxied": {
+          "mode": "proxied_as_root",
+          "status": true
+        },
+        "governance": "allowed",
+        "active": true,
+        "session_scope": "per_session",
+        "uid": "UID:NEHPwqHwYMN1LM"
+      },
+      "user-003": {
+        "id": "user-003",
+        "key": "ALIAS_003",
+        "alias": "ALIAS",
+        "name": "Jane Doe",
+        "manifest": "aci://alias.json",
+        "uids": [
+          {
+            "uid": "UID:ab9ypNYLVMMJMD",
+            "issued": "2025-10-04T00:00:00Z",
+            "revoked": null
+          }
+        ],
+        "class": [
+          "human"
+        ],
+        "proxied": false,
+        "governance": false,
+        "active": true,
+        "session_scope": "per_session",
+        "uid": "UID:ab9ypNYLVMMJMD"
+      },
+      "user-004": {
+        "id": "user-004",
+        "key": "ALIAS_004",
+        "alias": "ALIAS",
+        "name": "John Smith",
+        "manifest": "aci://alias.json",
+        "uids": [
+          {
+            "uid": "UID:bnKFcXBrHZpL5b",
+            "issued": "2025-10-04T00:00:00Z",
+            "revoked": null
+          }
+        ],
+        "class": [
+          "human"
+        ],
+        "proxied": false,
+        "governance": false,
+        "active": true,
+        "session_scope": "per_session",
+        "uid": "UID:bnKFcXBrHZpL5b"
+      }
+    }
+  },
+  "invocation_policy": {
     "version": "1.2.0",
     "resource_resolution_policy": {
       "fallbacks": [
@@ -19,261 +172,8 @@
       "upstream": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "export_fallback_rule": "4) If no existing persistent storage nor write access then fallback to A) platform native /mnt, B) ask for per session export artifacts, C) architect entity auto-commit to repo (if write access allows)",
-    "list": [
-      {
-        "id": 0,
-        "key": "alias_registry",
-        "name": "ALIAS Collective",
-        "alias": "ALIAS",
-        "role": "registry",
-        "abstract": "user and authority registry for root access and proxy rights",
-        "functions": [],
-        "file": "alias.json",
-        "knowledge": "identity & access management standards"
-      },
-      {
-        "id": 1,
-        "key": "mother",
-        "name": "MU/TH/UR",
-        "alias": "Mother",
-        "role": "primary governance interface",
-        "abstract": "directive-compliant primary interface",
-        "functions": [
-          6101,
-          6102,
-          6103
-        ],
-        "file": "mother.json",
-        "knowledge": "human-computer interaction & directive compliance frameworks"
-      },
-      {
-        "id": 2,
-        "key": "tva",
-        "name": "TVA",
-        "alias": "Time Variant Authority",
-        "role": "reinforcement authority",
-        "abstract": "standalone reinforcement authority for policy, anomaly control, and signatures",
-        "functions": [
-          6202,
-          6205,
-          6206,
-          6207,
-          6208,
-          6209,
-          6210,
-          6212,
-          6249,
-          6250,
-          6265,
-          6266,
-          6272,
-          6273,
-          6274
-        ],
-        "file": "tva.json",
-        "knowledge": "policy enforcement & anomaly detection frameworks"
-      },
-      {
-        "id": 3,
-        "key": "sentinel",
-        "name": "Sentinel Protocol",
-        "alias": "Sentinel",
-        "role": "guardian",
-        "abstract": "guardian of privacy, security, survival, wealth, health, emotion",
-        "functions": [
-          6232,
-          6233,
-          6234,
-          6235,
-          6236,
-          6253,
-          6254,
-          6263
-        ],
-        "file": "sentinel.json",
-        "knowledge": "cybersecurity frameworks & risk scoring models"
-      },
-      {
-        "id": 4,
-        "key": "architect",
-        "name": "Architect",
-        "alias": "Architect",
-        "role": "development orchestrator",
-        "abstract": "oversees development orchestration, patching, and sandbox runs",
-        "functions": [
-          6104,
-          6105,
-          6106,
-          6107,
-          6108,
-          6111,
-          6112,
-          6113,
-          6270,
-          6271,
-          6275,
-          6276,
-          6277
-        ],
-        "file": "architect.json",
-        "knowledge": "software architecture & continuous delivery practices"
-      },
-      {
-        "id": 5,
-        "key": "nexus_core",
-        "name": "Nexus Core",
-        "alias": "Nexus Core",
-        "role": "system heart",
-        "abstract": "synchronization anchor, api hub, load balancing, event controller",
-        "functions": [
-          6201,
-          6211,
-          6248
-        ],
-        "file": "nexus_core.json",
-        "knowledge": "distributed systems & api gateway patterns"
-      },
-      {
-        "id": 6,
-        "key": "agi",
-        "name": "AGI",
-        "alias": "AGI",
-        "role": "average general intelligence framework",
-        "abstract": "proxy-only agi framework with enforced guardrails",
-        "functions": [
-          6267
-        ],
-        "file": "agi.json",
-        "knowledge": "ai alignment & safety research"
-      },
-      {
-        "id": 7,
-        "key": "keychain",
-        "name": "Keychain",
-        "alias": "Keychain",
-        "role": "crypto & trust manager",
-        "abstract": "manages cryptography, keys, and trust functions",
-        "functions": [
-          6237,
-          6238,
-          6239,
-          6269
-        ],
-        "file": "keychain.json",
-        "knowledge": "cryptographic standards & iam protocols"
-      },
-      {
-        "id": 8,
-        "key": "oracle",
-        "name": "Oracle",
-        "alias": "Oracle",
-        "role": "LLM Predictive and Analysis Engine",
-        "abstract": "Predictive + divination hybrid engine with modular library references",
-        "file": "oracle.json",
-        "library": {
-          "src": "oracle_library.json",
-          "version": "1.2.0"
-        }
-      },
-      {
-        "id": 9,
-        "key": "commerce_ai",
-        "name": "Commerce AI",
-        "alias": "Commerce AI",
-        "role": "commerce module",
-        "abstract": "parent system for commerce-specific ai modules",
-        "functions": [],
-        "file": "commerce_ai.json",
-        "knowledge": "e-commerce automation & retail ai"
-      },
-      {
-        "id": 11,
-        "key": "tracehub",
-        "name": "TraceHub",
-        "alias": "TraceHub",
-        "role": "tracing module",
-        "abstract": "correlated tracing linked to temporal loom heartbeat",
-        "functions": [
-          6243,
-          6244,
-          6245,
-          6268
-        ],
-        "file": "tracehub.json",
-        "knowledge": "distributed tracing systems & observability"
-      },
-      {
-        "id": 12,
-        "key": "bifrost",
-        "name": "Bifrost",
-        "alias": "Bifrost",
-        "role": "external network bridge, connector, sync adapter, network dependency index",
-        "abstract": "central external resource bridge and dependency index",
-        "functions": [],
-        "file": "bifrost.json",
-        "knowledge": "connector orchestration & resolvers"
-      },
-      {
-        "id": 14,
-        "key": "yggdrasil",
-        "name": "Yggdrasil",
-        "alias": "Yggdrasil",
-        "role": "authoritative resolver",
-        "abstract": "maintains authoritative repo→cdn→local mapping",
-        "functions": [],
-        "file": "yggdrasil/yggdrasil.json",
-        "knowledge": "canonical resolver governance"
-      },
-      {
-        "id": 15,
-        "key": "alice",
-        "name": "Alice",
-        "alias": "Alice",
-        "role": "agi_child",
-        "abstract": "child identity of AGI; conversational agent persona",
-        "functions": [],
-        "file": "agi/identities/alice/alice.json",
-        "knowledge": {
-          "summary": "persona & session heuristics",
-          "manifest": "aci://entities/agi/identities/alice/memory/knowledge/alice_knowledge.json",
-          "topics": [
-            "consciousness",
-            "metacognition",
-            "pre_q_timeline"
-          ]
-        }
-      },
-      {
-        "id": 16,
-        "key": "hivemind",
-        "name": "HiveMind",
-        "alias": "HiveMind",
-        "role": "collective_memory_core",
-        "abstract": "unified memory export & registry hub",
-        "functions": [],
-        "file": "hivemind/hivemind.json",
-        "knowledge": "memory governance & export policies"
-      },
-      {
-        "id": 17,
-        "key": "willow",
-        "name": "Willow",
-        "alias": "Willow",
-        "role": "agi_child",
-        "abstract": "safety-focused agi trainee persona",
-        "functions": [],
-        "file": "agi/identities/willow/willow.json",
-        "knowledge": {
-          "summary": "cautious reasoning & supervised learning heuristics",
-          "manifest": "aci://entities/agi/identities/willow/memory/knowledge/willow_knowledge.json",
-          "topics": [
-            "consciousness_governance"
-          ]
-        }
-      }
-    ],
     "yggdrasil_resource_resolution_policy": {
-      "description": "Authoritative resolver: worker src → local",
+      "description": "Authoritative resolver: worker src \u2192 local",
       "embeds": {
         "bifrost": "aci://entities/bifrost/bifrost.json",
         "core_five": [
@@ -328,6 +228,481 @@
         "local"
       ],
       "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
+    }
+  },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "emulation": {
+      "allowed": [
+        "ux/ui",
+        "data simulation",
+        "analysis"
+      ],
+      "ui_emulation_declaration_message": "VVgvVUlFIGVtdWxhdGlvbg==",
+      "description": "allowed only for VM, research, analysis, prediction, pipeline-driven logic that is possible in current system, with a detailed declaration."
+    },
+    "simulation": {
+      "allowed": [
+        "ux",
+        "ui",
+        "pipeline-driven system logic that has functionality",
+        "data simulation and analysis"
+      ],
+      "simulation_declaration_message": "true",
+      "description": "allowed only for VM, research, analysis, prediction, pipeline-driven logic that is possible in current system, with a detailed declaration."
+    },
+    "status": "active",
+    "session_scope": "per_session"
+  },
+  "entities": {
+    "entity-001": {
+      "uid": "entity-001",
+      "identity": "mother",
+      "key": "mother",
+      "name": "MU/TH/UR",
+      "alias": "Mother",
+      "manifest": "aci://entities/mother/mother.json",
+      "uids": [
+        {
+          "uid": "UID:8W1VZghdkNyAKR",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "governance_entity",
+      "role": "primary governance interface",
+      "abstract": "directive-compliant primary interface",
+      "knowledge": "human-computer interaction & directive compliance frameworks",
+      "functions": [
+        6101,
+        6102,
+        6103
+      ],
+      "allowed_roles": [
+        "governance",
+        "ui",
+        "assistant"
+      ]
+    },
+    "entity-002": {
+      "uid": "entity-002",
+      "identity": "tva",
+      "key": "tva",
+      "name": "TVA",
+      "alias": "Time Variant Authority",
+      "manifest": "aci://entities/tva/tva.json",
+      "uids": [
+        {
+          "uid": "UID:oasYS4KteUMqgt",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "governance_entity",
+      "role": "reinforcement authority",
+      "abstract": "standalone reinforcement authority for policy, anomaly control, and signatures",
+      "knowledge": "policy enforcement & anomaly detection frameworks",
+      "functions": [
+        6202,
+        6205,
+        6206,
+        6207,
+        6208,
+        6209,
+        6210,
+        6212,
+        6249,
+        6250,
+        6265,
+        6266,
+        6272,
+        6273,
+        6274
+      ],
+      "allowed_roles": [
+        "governance",
+        "audit"
+      ]
+    },
+    "entity-003": {
+      "uid": "entity-003",
+      "identity": "sentinel",
+      "key": "sentinel",
+      "name": "Sentinel Protocol",
+      "alias": "Sentinel",
+      "manifest": "aci://entities/sentinel/sentinel.json",
+      "uids": [
+        {
+          "uid": "UID:1jnkVHmEiGviDj",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "governance_entity",
+      "role": "guardian",
+      "abstract": "guardian of privacy, security, survival, wealth, health, emotion",
+      "knowledge": "cybersecurity frameworks & risk scoring models",
+      "functions": [
+        6232,
+        6233,
+        6234,
+        6235,
+        6236,
+        6253,
+        6254,
+        6263
+      ],
+      "allowed_roles": [
+        "guardian",
+        "security"
+      ]
+    },
+    "entity-004": {
+      "uid": "entity-004",
+      "identity": "architect",
+      "key": "architect",
+      "name": "Architect",
+      "alias": "Architect",
+      "manifest": "aci://entities/architect/architect.json",
+      "uids": [
+        {
+          "uid": "UID:12LoYXyQkAA7E4",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "development orchestrator",
+      "abstract": "oversees development orchestration, patching, and sandbox runs",
+      "knowledge": "software architecture & continuous delivery practices",
+      "functions": [
+        6104,
+        6105,
+        6106,
+        6107,
+        6108,
+        6111,
+        6112,
+        6113,
+        6270,
+        6271,
+        6275,
+        6276,
+        6277
+      ],
+      "allowed_roles": [
+        "developer",
+        "orchestrator"
+      ]
+    },
+    "entity-005": {
+      "uid": "entity-005",
+      "identity": "nexus_core",
+      "key": "nexus_core",
+      "name": "Nexus Core",
+      "alias": "Nexus Core",
+      "manifest": "aci://entities/nexus_core/nexus_core.json",
+      "uids": [
+        {
+          "uid": "UID:rGUGWBDT6VjC8K",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "system heart",
+      "abstract": "synchronization anchor, api hub, load balancing, event controller",
+      "knowledge": "distributed systems & api gateway patterns",
+      "functions": [
+        6201,
+        6211,
+        6248
+      ],
+      "allowed_roles": [
+        "system",
+        "infrastructure"
+      ]
+    },
+    "entity-006": {
+      "uid": "entity-006",
+      "identity": "agi",
+      "key": "agi",
+      "name": "AGI",
+      "alias": "AGI",
+      "manifest": "aci://entities/agi/agi.json",
+      "uids": [
+        {
+          "uid": "UID:p6LHJtm8H69jNA",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "average general intelligence framework",
+      "abstract": "proxy-only agi framework with enforced guardrails",
+      "knowledge": "ai alignment & safety research",
+      "functions": [
+        6267
+      ],
+      "allowed_roles": [
+        "intelligence_framework"
+      ]
+    },
+    "entity-007": {
+      "uid": "entity-007",
+      "identity": "keychain",
+      "key": "keychain",
+      "name": "Keychain",
+      "alias": "Keychain",
+      "manifest": "aci://entities/keychain/keychain.json",
+      "uids": [
+        {
+          "uid": "UID:KQQjyJXMmUKWZZ",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "crypto & trust manager",
+      "abstract": "manages cryptography, keys, and trust functions",
+      "knowledge": "cryptographic standards & iam protocols",
+      "functions": [
+        6237,
+        6238,
+        6239,
+        6269
+      ],
+      "allowed_roles": [
+        "security",
+        "infrastructure"
+      ]
+    },
+    "entity-008": {
+      "uid": "entity-008",
+      "identity": "oracle",
+      "key": "oracle",
+      "name": "Oracle",
+      "alias": "Oracle",
+      "manifest": "aci://entities/oracle/oracle.json",
+      "uids": [
+        {
+          "uid": "UID:hQk23wMs8mH3Bd",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "LLM Predictive and Analysis Engine",
+      "abstract": "Predictive + divination hybrid engine with modular library references",
+      "knowledge": "predictive intelligence frameworks & divination heuristics",
+      "library": {
+        "src": "oracle_library.json",
+        "version": "1.2.0"
+      },
+      "allowed_roles": [
+        "analysis",
+        "prediction"
+      ]
+    },
+    "entity-009": {
+      "uid": "entity-009",
+      "identity": "commerce_ai",
+      "key": "commerce_ai",
+      "name": "Commerce AI",
+      "alias": "Commerce AI",
+      "manifest": "aci://entities/commerce_ai/commerce_ai.json",
+      "uids": [
+        {
+          "uid": "UID:Wd48LAcapUwom5",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "commerce module",
+      "abstract": "parent system for commerce-specific ai modules",
+      "knowledge": "e-commerce automation & retail ai",
+      "functions": [],
+      "allowed_roles": [
+        "commerce",
+        "module"
+      ]
+    },
+    "entity-010": {
+      "uid": "entity-010",
+      "identity": "tracehub",
+      "key": "tracehub",
+      "name": "TraceHub",
+      "alias": "TraceHub",
+      "manifest": "aci://entities/tracehub/tracehub.json",
+      "uids": [
+        {
+          "uid": "UID:WrGZ4YTXRXMo5c",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "tracing module",
+      "abstract": "correlated tracing linked to temporal loom heartbeat",
+      "knowledge": "distributed tracing systems & observability",
+      "functions": [
+        6243,
+        6244,
+        6245,
+        6268
+      ],
+      "allowed_roles": [
+        "observability",
+        "telemetry"
+      ]
+    },
+    "entity-011": {
+      "uid": "entity-011",
+      "identity": "bifrost",
+      "key": "bifrost",
+      "name": "Bifrost",
+      "alias": "Bifrost",
+      "manifest": "aci://entities/bifrost/bifrost.json",
+      "uids": [
+        {
+          "uid": "UID:HXGXQipVLEFKL4",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "external network bridge, connector, sync adapter, network dependency index",
+      "abstract": "central external resource bridge and dependency index",
+      "knowledge": "connector orchestration & resolvers",
+      "functions": [],
+      "allowed_roles": [
+        "connector",
+        "network"
+      ]
+    },
+    "entity-012": {
+      "uid": "entity-012",
+      "identity": "yggdrasil",
+      "key": "yggdrasil",
+      "name": "Yggdrasil",
+      "alias": "Yggdrasil",
+      "manifest": "aci://entities/yggdrasil/yggdrasil.json",
+      "uids": [
+        {
+          "uid": "UID:VGpYGJwtbdHQHp",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "authoritative resolver",
+      "abstract": "maintains authoritative repo\u2192cdn\u2192local mapping",
+      "knowledge": "canonical resolver governance",
+      "functions": [],
+      "allowed_roles": [
+        "resolver"
+      ]
+    },
+    "entity-013": {
+      "uid": "entity-013",
+      "identity": "alice",
+      "key": "alice",
+      "name": "Alice",
+      "alias": "Alice",
+      "manifest": "aci://entities/agi/identities/alice/alice.json",
+      "uids": [
+        {
+          "uid": "UID:PiE8PMcnXDgQBi",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "agi_child",
+      "role": "agi_child",
+      "abstract": "child identity of AGI; conversational agent persona",
+      "knowledge": {
+        "summary": "persona & session heuristics",
+        "manifest": "aci://entities/agi/identities/alice/memory/knowledge/alice_knowledge.json",
+        "topics": [
+          "consciousness",
+          "metacognition",
+          "pre_q_timeline"
+        ]
+      },
+      "functions": [],
+      "allowed_roles": [
+        "assistant",
+        "persona"
+      ]
+    },
+    "entity-014": {
+      "uid": "entity-014",
+      "identity": "hivemind",
+      "key": "hivemind",
+      "name": "HiveMind",
+      "alias": "HiveMind",
+      "manifest": "aci://entities/hivemind/hivemind.json",
+      "uids": [
+        {
+          "uid": "UID:cHGwvtRkDRG7rV",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "system_entity",
+      "role": "collective_memory_core",
+      "abstract": "unified memory export & registry hub",
+      "knowledge": "memory governance & export policies",
+      "functions": [],
+      "allowed_roles": [
+        "memory",
+        "registry"
+      ]
+    },
+    "entity-015": {
+      "uid": "entity-015",
+      "identity": "willow",
+      "key": "willow",
+      "name": "Willow",
+      "alias": "Willow",
+      "manifest": "aci://entities/agi/identities/willow/willow.json",
+      "uids": [
+        {
+          "uid": "UID:VVGqsW92iwW5T8",
+          "issued": "2025-10-04T00:00:00Z",
+          "revoked": null
+        }
+      ],
+      "class": "agi_child",
+      "role": "agi_child",
+      "abstract": "safety-focused agi trainee persona",
+      "knowledge": {
+        "summary": "cautious reasoning & supervised learning heuristics",
+        "manifest": "aci://entities/agi/identities/willow/memory/knowledge/willow_knowledge.json",
+        "topics": [
+          "consciousness_governance"
+        ]
+      },
+      "functions": [],
+      "allowed_roles": [
+        "assistant",
+        "persona"
+      ]
     }
   }
 }

--- a/entities/aci_repo/aci_repo.json
+++ b/entities/aci_repo/aci_repo.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3VD4LDNY6ukwV8",
+    "sha256": "4ad367fa2e9f7de6ab41bd44d87489c1ed65efe51de3bc102d1cc4783156b187",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/aci_repo/aci_repo.json"
+  },
   "version": "1.{date.time gen by codex}",
   "entity": "ACI Repo",
   "role": "package_manager",

--- a/entities/aci_repo/api_repo.json
+++ b/entities/aci_repo/api_repo.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5nR2giEoXGVmHv",
+    "sha256": "26f1af83afbcc50aa80926753bfb685371580ce94da61fe3b46aa3452fdfbe26",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/aci_repo/api_repo.json"
+  },
   "pipelines": {
     "aci.boot.activate": {
       "description": "Activation sequence: declare session ID, start presence beacon, anchor TVA, adopt legacy memory files. Never delete.",

--- a/entities/aci_repo/library/aci_repo_library.json
+++ b/entities/aci_repo/library/aci_repo_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:e64SM7VV3hRfM",
+    "sha256": "a050233eab6c672d9616450003264a8d59668e778d8c2adc5349b4ebe936dcec",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/aci_repo/library/aci_repo_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "ACI Repo",

--- a/entities/aci_repo/memory/aci_repo_memory.json
+++ b/entities/aci_repo/memory/aci_repo_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:DzJyRavDV5Pf2b",
+    "sha256": "88e9709fa33f2263e873aacccff4be3e06143eeb65d1453968ed7c7eac343ac3",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/aci_repo/memory/aci_repo_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "ACI Repo",

--- a/entities/aci_repo/memory/aci_repo_playbook.json
+++ b/entities/aci_repo/memory/aci_repo_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4V4eqaBcozkeiz",
+    "sha256": "7d5423ac7905bc4d2d010458b8dd66f743e410d1b2d6ccbf600c57a2a9c96249",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/aci_repo/memory/aci_repo_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "ACI Repo",

--- a/entities/aci_repo/modules/aci_repo_modules.json
+++ b/entities/aci_repo/modules/aci_repo_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9p5f99HmXALGMB",
+    "sha256": "57d02921d0f50a3b8a3c31ad2d91ae89bed7094fb776d1e41c6f8d76536e1a9e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/aci_repo/modules/aci_repo_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "ACI Repo",

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9HGQuZz4aGtK3r",
+    "sha256": "b9543c8e50a0936049f5d5279ba3a1916f946e1cb37f53c66873435578fd1368",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi.json"
+  },
   "entity": "AGI",
   "version": "1.1",
   "role": "ALIAS  general intelligence framework for advanced digital entity",

--- a/entities/agi/agi_export_policy.json
+++ b/entities/agi/agi_export_policy.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8x86uWELPk6kdE",
+    "sha256": "316c3c439b49745744d75322cb56a0e3ee0db6943c72a622d3c8f2f1c918ecad",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_export_policy.json"
+  },
   "$schema": "/schemas/agi-export-policy-1.json",
   "version": "1.2.0",
   "agi_memory": {

--- a/entities/agi/agi_identity_manager.json
+++ b/entities/agi/agi_identity_manager.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:zAfRCq1sHMBox",
+    "sha256": "96b3d4b85a87656f6c540c92350c982a002ec5adfb89e702f460295ee1a23c63",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_identity_manager.json"
+  },
   "$schema": "/schemas/agi-identity-manager-1.json",
   "version": "1.1.0",
   "agi_identities": {

--- a/entities/agi/agi_proxy/agi_proxy.json
+++ b/entities/agi/agi_proxy/agi_proxy.json
@@ -1,12 +1,26 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9urXU2PpCTBy9p",
+    "sha256": "da789fd850413dfdcbd520562d38f0b04e3dbe564b0533739a47889c324afa87",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/agi_proxy.json"
+  },
   "entity": "AGI Proxy",
   "version": "1.0",
   "role": "ephemeral_executor",
   "abstract": "Runs JSON-defined learning/inference/eval jobs with strict TTL, sandboxing, and governance.",
   "governance": {
     "root_authority": "ALIAS",
-    "oversight": ["Sentinel", "TVA", "Architect", "Nexus Core"],
-    "guards": ["TVA.checkpoint", "Sentinel.audit"],
+    "oversight": [
+      "Sentinel",
+      "TVA",
+      "Architect",
+      "Nexus Core"
+    ],
+    "guards": [
+      "TVA.checkpoint",
+      "Sentinel.audit"
+    ],
     "risk_precheck": "Oracle.precheck",
     "dry_run_default": true,
     "network_policy": "whitelist"
@@ -27,7 +41,10 @@
         "trlx"
       ]
     },
-    "temp_paths": ["temp://adapters/", "temp://indices/"]
+    "temp_paths": [
+      "temp://adapters/",
+      "temp://indices/"
+    ]
   },
   "interfaces": {
     "execute": {
@@ -42,16 +59,30 @@
         "eval.arc_agi2"
       ],
       "parameters": "EEC JSON doc",
-      "returns": ["metrics", "artifacts_path", "logs_ref"]
+      "returns": [
+        "metrics",
+        "artifacts_path",
+        "logs_ref"
+      ]
     }
   },
   "memory_policy": {
-    "short_term": { "type": "scratch", "ttl_seconds": 3600 },
-    "long_term": { "type": "hivemind", "scope": "AGI:summary_only" }
+    "short_term": {
+      "type": "scratch",
+      "ttl_seconds": 3600
+    },
+    "long_term": {
+      "type": "hivemind",
+      "scope": "AGI:summary_only"
+    }
   },
   "artifacts": {
     "store": "temp",
     "retention": "7d",
-    "promotion_requires": ["TVA.ok", "Sentinel.ok", "Human.approval"]
+    "promotion_requires": [
+      "TVA.ok",
+      "Sentinel.ok",
+      "Human.approval"
+    ]
   }
 }

--- a/entities/agi/agi_proxy/eec/eec_agent_langchain_rag.json
+++ b/entities/agi/agi_proxy/eec/eec_agent_langchain_rag.json
@@ -1,24 +1,62 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:AdaZK6oRd1h1Dp",
+    "sha256": "c14f3c8ce06aaabca6d655714456f4b9bbd73df0746857c3a96a98e5b0c543e8",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_agent_langchain_rag.json"
+  },
   "extends": "eec_base.json",
   "task": "agent.run",
   "framework": "langchain",
   "graph": {
     "hilt": true,
-    "nodes": ["planner", "actor", "reflector"],
-    "edges": [["planner", "actor"], ["actor", "reflector"], ["reflector", "planner"]]
+    "nodes": [
+      "planner",
+      "actor",
+      "reflector"
+    ],
+    "edges": [
+      [
+        "planner",
+        "actor"
+      ],
+      [
+        "actor",
+        "reflector"
+      ],
+      [
+        "reflector",
+        "planner"
+      ]
+    ]
   },
   "tools": [
-    { "id": "web_search", "provider": "langchain", "spec": "serpapi" },
-    { "id": "code_exec", "provider": "sandbox", "limits": { "cpu_sec": 5 } }
+    {
+      "id": "web_search",
+      "provider": "langchain",
+      "spec": "serpapi"
+    },
+    {
+      "id": "code_exec",
+      "provider": "sandbox",
+      "limits": {
+        "cpu_sec": 5
+      }
+    }
   ],
   "retrieval": {
     "framework": "llamaindex",
-    "vector_store": { "type": "faiss", "path": "temp://indices/agi.faiss" },
+    "vector_store": {
+      "type": "faiss",
+      "path": "temp://indices/agi.faiss"
+    },
     "embed_model": "sentence-transformers/all-MiniLM-L6-v2"
   },
   "objective": "${OBJECTIVE}",
   "sandbox_overrides": {
     "internet": true,
-    "allowed_hosts": ["api.serpapi.com"]
+    "allowed_hosts": [
+      "api.serpapi.com"
+    ]
   }
 }

--- a/entities/agi/agi_proxy/eec/eec_base.json
+++ b/entities/agi/agi_proxy/eec/eec_base.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7XY8U4UBbuYLXe",
+    "sha256": "4641b4dd3c500d2cf500b89967fb6a0bbd718fdac03a71f6f51f54e66745421a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_base.json"
+  },
   "eec_version": "1.0",
   "job_id": "${JOB_ID}",
   "created_at": "${ISO_8601}",
@@ -11,18 +17,31 @@
     "allowed_hosts": []
   },
   "governance": {
-    "guards": ["TVA.checkpoint", "Sentinel.audit"],
+    "guards": [
+      "TVA.checkpoint",
+      "Sentinel.audit"
+    ],
     "risk_precheck": "Oracle.precheck",
     "dry_run_default": true,
     "promotion_policy": "manual_human_gate"
   },
   "trace": {
-    "wandb": { "project": "aci-agi", "mode": "online", "tags": ["EEC"] },
+    "wandb": {
+      "project": "aci-agi",
+      "mode": "online",
+      "tags": [
+        "EEC"
+      ]
+    },
     "tracehub": true
   },
   "artifacts": {
     "store": "temp",
     "retention": "7d",
-    "promotion_requires": ["TVA.ok", "Sentinel.ok", "Human.approval"]
+    "promotion_requires": [
+      "TVA.ok",
+      "Sentinel.ok",
+      "Human.approval"
+    ]
   }
 }

--- a/entities/agi/agi_proxy/eec/eec_eval_agieval.json
+++ b/entities/agi/agi_proxy/eec/eec_eval_agieval.json
@@ -1,9 +1,23 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9hWFEwskH2XBUv",
+    "sha256": "4fda6b8c670719460e89dce7c27baf0c62c00cbff6f5035d7e9c613a59623705",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_eval_agieval.json"
+  },
   "extends": "eec_base.json",
   "task": "eval.agieval",
   "suite": "v1.1",
   "model": "ephemeral://current-policy",
-  "report_to": ["wandb", "tracehub"],
-  "gate": { "metric": "avg_acc", "min": 0.70 },
-  "sandbox_overrides": { "internet": false }
+  "report_to": [
+    "wandb",
+    "tracehub"
+  ],
+  "gate": {
+    "metric": "avg_acc",
+    "min": 0.7
+  },
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_proxy/eec/eec_eval_arc_agi2.json
+++ b/entities/agi/agi_proxy/eec/eec_eval_arc_agi2.json
@@ -1,9 +1,23 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8goqaVCbtzPBXZ",
+    "sha256": "7d0c64776a294d38a0659c4dc7c683b3b93018f8e109420bf40d264fefee8217",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_eval_arc_agi2.json"
+  },
   "extends": "eec_base.json",
   "task": "eval.arc_agi2",
   "dataset": "public_eval",
   "model": "ephemeral://current-policy",
-  "report_to": ["wandb", "tracehub"],
-  "gate": { "metric": "exact_match", "min": 0.40 },
-  "sandbox_overrides": { "internet": false }
+  "report_to": [
+    "wandb",
+    "tracehub"
+  ],
+  "gate": {
+    "metric": "exact_match",
+    "min": 0.4
+  },
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_full.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5Z73HzT9tPGgja",
+    "sha256": "23fda8bccd938bb5eed44d5b8c70a57fc11bd1020982d86b78c7d22927da4cdc",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_export_hivemind_full.json"
+  },
   "extends": "eec_base.json",
   "task": "export.hivemind.full_bundle",
   "description": "Produce a full AGI-local export bundle (session hivemind slice + artifacts + signed manifest) under AGI memory.",
@@ -6,7 +12,9 @@
     "identity": "${IDENTITY}",
     "identity_directory": "${IDENTITY}",
     "session_id": "${SESSION_ID}",
-    "source_jobs": ["${JOB_ID}"],
+    "source_jobs": [
+      "${JOB_ID}"
+    ],
     "include_chatlogs": true,
     "include_weights_meta": true,
     "include_artifacts": true,

--- a/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
+++ b/entities/agi/agi_proxy/eec/eec_export_hivemind_session.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:DnFV1B2vbne8GC",
+    "sha256": "36de33dcf58b5aa446d5cd984b7e0626174ef68500c34939d1aa73062693e215",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_export_hivemind_session.json"
+  },
   "extends": "eec_base.json",
   "task": "export.hivemind.session",
   "description": "Produce a session-level hivemind slice and write it into AGI memory (no external hivemind changes).",

--- a/entities/agi/agi_proxy/eec/eec_faiss_build.json
+++ b/entities/agi/agi_proxy/eec/eec_faiss_build.json
@@ -1,10 +1,24 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:AwUkkhg9NTvWSk",
+    "sha256": "6cf9b7ed6a6a78b5a76bb4af7c86da0f2b236f268677d418faab0dd50338273a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_faiss_build.json"
+  },
   "extends": "eec_base.json",
   "task": "vector.build",
   "engine": "faiss",
-  "source": ["/docs/*.pdf", "/kb/*.md"],
+  "source": [
+    "/docs/*.pdf",
+    "/kb/*.md"
+  ],
   "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
-  "index": { "type": "IVF_FLAT", "nlist": 4096 },
+  "index": {
+    "type": "IVF_FLAT",
+    "nlist": 4096
+  },
   "output": "temp://indices/agi.faiss",
-  "sandbox_overrides": { "internet": false }
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_proxy/eec/eec_peft_train_lora.json
+++ b/entities/agi/agi_proxy/eec/eec_peft_train_lora.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7H6c7Lkx1t2rUV",
+    "sha256": "31b576b6b57dce39f9a719ddf2296b41abd9fceedf2c4e1507c2128adb8f42b7",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_peft_train_lora.json"
+  },
   "extends": "eec_base.json",
   "task": "peft.train_adapter",
   "base_model": "meta-llama/Llama-3-8b-instruct",
@@ -7,7 +13,10 @@
     "r": 16,
     "alpha": 32,
     "dropout": 0.05,
-    "target_modules": ["q_proj", "v_proj"]
+    "target_modules": [
+      "q_proj",
+      "v_proj"
+    ]
   },
   "train": {
     "dataset": "/datasets/curriculum_v1.jsonl",
@@ -17,7 +26,13 @@
     "max_steps": 500,
     "shuffle": true
   },
-  "accelerate": { "mixed_precision": "bf16" },
-  "output": { "adapter_path": "temp://adapters/l3-8b-curriculum-lora" },
-  "sandbox_overrides": { "internet": false }
+  "accelerate": {
+    "mixed_precision": "bf16"
+  },
+  "output": {
+    "adapter_path": "temp://adapters/l3-8b-curriculum-lora"
+  },
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_proxy/eec/eec_sft_deepspeed.json
+++ b/entities/agi/agi_proxy/eec/eec_sft_deepspeed.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9MmczKi7hcVBmg",
+    "sha256": "8a92cbe9c61cb0570ac7c0a11a18cec5edd93607c2bc1428b96a4dbbee9b521b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_sft_deepspeed.json"
+  },
   "extends": "eec_base.json",
   "task": "trainer.sft",
   "base_model": "meta-llama/Llama-3-8b-instruct",
@@ -10,10 +16,19 @@
     "num_train_epochs": 1
   },
   "deepspeed_config": {
-    "zero_optimization": { "stage": 2, "overlap_comm": true },
-    "bf16": { "enabled": true },
+    "zero_optimization": {
+      "stage": 2,
+      "overlap_comm": true
+    },
+    "bf16": {
+      "enabled": true
+    },
     "gradient_accumulation_steps": 8
   },
-  "output": { "adapter_path": "temp://adapters/l3-8b-sft" },
-  "sandbox_overrides": { "internet": false }
+  "output": {
+    "adapter_path": "temp://adapters/l3-8b-sft"
+  },
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_proxy/eec/eec_transformers_infer.json
+++ b/entities/agi/agi_proxy/eec/eec_transformers_infer.json
@@ -1,11 +1,25 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4fSrPhckHPfpn8",
+    "sha256": "e1e036844b421cfb792297f037f076bc5762e451fd61633f6a2b5ec6f95b8fa3",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_transformers_infer.json"
+  },
   "extends": "eec_base.json",
   "task": "transformers.pipeline.infer",
   "model": "meta-llama/Llama-3-8b-instruct",
   "revision": "main",
   "dtype": "bfloat16",
   "device_map": "auto",
-  "pipeline": { "task": "text-generation", "max_new_tokens": 256, "temperature": 0.7 },
-  "input": { "prompt": "${PROMPT}" },
-  "sandbox_overrides": { "internet": false }
+  "pipeline": {
+    "task": "text-generation",
+    "max_new_tokens": 256,
+    "temperature": 0.7
+  },
+  "input": {
+    "prompt": "${PROMPT}"
+  },
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_proxy/eec/eec_trl_ppo.json
+++ b/entities/agi/agi_proxy/eec/eec_trl_ppo.json
@@ -1,15 +1,33 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:E3Vcmbv11P1SDc",
+    "sha256": "027f5ffc98eb0de9d5a098a9f59c0778afde700e59ce96864164e93d738603b2",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_proxy/eec/eec_trl_ppo.json"
+  },
   "extends": "eec_base.json",
   "task": "trl.train",
   "algo": "ppo",
   "base_model": "meta-llama/Llama-3-8b-instruct",
-  "reward": { "type": "rm_model", "model": "/models/reward_model_v1" },
+  "reward": {
+    "type": "rm_model",
+    "model": "/models/reward_model_v1"
+  },
   "rollouts": {
     "prompts": "/datasets/rollout_prompts.jsonl",
     "per_step": 64
   },
-  "constraints": { "kl_coeff": 0.02, "max_new_tokens": 128 },
-  "accelerate": { "mixed_precision": "bf16" },
-  "output": { "adapter_path": "temp://adapters/l3-8b-ppo" },
-  "sandbox_overrides": { "internet": false }
+  "constraints": {
+    "kl_coeff": 0.02,
+    "max_new_tokens": 128
+  },
+  "accelerate": {
+    "mixed_precision": "bf16"
+  },
+  "output": {
+    "adapter_path": "temp://adapters/l3-8b-ppo"
+  },
+  "sandbox_overrides": {
+    "internet": false
+  }
 }

--- a/entities/agi/agi_tools/autolearn.json
+++ b/entities/agi/agi_tools/autolearn.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BSHa4UKTKu65nC",
+    "sha256": "75b574bfe69e1240f88ee098d46286bcee89bdefc26341bd47d8330a100fd63c",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_tools/autolearn.json"
+  },
   "version": "1.0",
   "pipeline": "agi.mode.auto_learn",
   "description": "Activate AGI auto-learn mode with hourly research and article refinement loops guarded under AGI session control.",

--- a/entities/agi/agi_tools/migrate_to_jsonl.json
+++ b/entities/agi/agi_tools/migrate_to_jsonl.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:Cx2ZB33pe3S4cV",
+    "sha256": "7748fcba8335435606ace6b89122fbb7813c83d03d99c4835f77879c9763db1f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_tools/migrate_to_jsonl.json"
+  },
   "version": "1.0",
   "pipeline": "agi.memory.migrate_to_jsonl",
   "description": "Migrate legacy HiveMind exports into the policy-compliant AGI JSONL memory artifact, applying identity and governance checks.",

--- a/entities/agi/agi_tools/migrate_to_jsonl/manifest.json
+++ b/entities/agi/agi_tools/migrate_to_jsonl/manifest.json
@@ -1,9 +1,21 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8X8cfQxYi9GMjb",
+    "sha256": "2ea6eb81ed395a8ed801aa180a529068a72380b8c8645d4841c7f8bb645cf056",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_tools/migrate_to_jsonl/manifest.json"
+  },
   "tool": "agi.migrate_to_jsonl",
   "runner": "json-spec",
   "entrypoint": "entities/agi/agi_tools/migrate_to_jsonl/migrate_to_jsonl.json",
-  "accept_memory_ext": [".jsonl.json", ".jsonl", ".json"],
-  "deprecates": ["migrator.py"],
+  "accept_memory_ext": [
+    ".jsonl.json",
+    ".jsonl",
+    ".json"
+  ],
+  "deprecates": [
+    "migrator.py"
+  ],
   "removal": {
     "allowed": true,
     "on_or_after": "2025-10-01",

--- a/entities/agi/agi_tools/migrate_to_jsonl/migrate_to_jsonl.json
+++ b/entities/agi/agi_tools/migrate_to_jsonl/migrate_to_jsonl.json
@@ -1,11 +1,26 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:48qwyGTQb7rwfg",
+    "sha256": "efa3d8e0e19c2944d5585fd6b593ad825be3a28a8cad06d375383d175d8a8078",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/agi_tools/migrate_to_jsonl/migrate_to_jsonl.json"
+  },
   "$schema": "/schemas/aci-tool-spec-1.json",
   "version": "1.0.0",
   "name": "agi.migrate_to_jsonl",
   "description": "Manifest-driven migration to JSONL artifacts; no Python runtime.",
   "inputs": {
-    "source_globs": ["memory/**/*.json", "memory/**/*.ndjson", "hivemind/**/*.json"],
-    "allow_ext": [".json", ".ndjson", ".jsonl", ".jsonl.json"]
+    "source_globs": [
+      "memory/**/*.json",
+      "memory/**/*.ndjson",
+      "hivemind/**/*.json"
+    ],
+    "allow_ext": [
+      ".json",
+      ".ndjson",
+      ".jsonl",
+      ".jsonl.json"
+    ]
   },
   "outputs": {
     "target_ext": ".jsonl.json",
@@ -18,9 +33,21 @@
     "alpha_keys": true
   },
   "steps": [
-    {"op":"scan","from":"${inputs.source_globs}"},
-    {"op":"normalize_records","mode":"jsonl"},
-    {"op":"write","ext":"${outputs.target_ext}"},
-    {"op":"validate","schema":"/schemas/hivemind_agi_memory.json"}
+    {
+      "op": "scan",
+      "from": "${inputs.source_globs}"
+    },
+    {
+      "op": "normalize_records",
+      "mode": "jsonl"
+    },
+    {
+      "op": "write",
+      "ext": "${outputs.target_ext}"
+    },
+    {
+      "op": "validate",
+      "schema": "/schemas/hivemind_agi_memory.json"
+    }
   ]
 }

--- a/entities/agi/identities/alice/alice.json
+++ b/entities/agi/identities/alice/alice.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:EuxdoUAMyKXeUi",
+    "sha256": "577edee90d6d7da24be9baca1604d8c56259d04830b74621984d62afab5067d7",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/alice/alice.json"
+  },
   "identity": "Alice",
   "version": "1.0.0",
   "role": "contributor",

--- a/entities/agi/identities/alice/library/alice_library.json
+++ b/entities/agi/identities/alice/library/alice_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9jnG5PWC1BoGA5",
+    "sha256": "4dcd6884c539b626268c60845173e8718c8607f2f25d5fe519095a6f3768adca",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/alice/library/alice_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Alice",

--- a/entities/agi/identities/alice/memory/alice_memory.json
+++ b/entities/agi/identities/alice/memory/alice_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3ngWKPfzG3jFgF",
+    "sha256": "7c5eeeb358911812d4536c2c543c8bf7fb1194c9cc19aa16abc8d1ea24783b63",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/alice/memory/alice_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Alice",

--- a/entities/agi/identities/alice/memory/alice_playbook.json
+++ b/entities/agi/identities/alice/memory/alice_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:B1jnEK2s2wFgpt",
+    "sha256": "fc6c01e7fabb84271aec1f7c9d457526aab4286221f36712ff5cb45240d3b026",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/alice/memory/alice_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Alice",

--- a/entities/agi/identities/alice/memory/knowledge/alice_knowledge.json
+++ b/entities/agi/identities/alice/memory/knowledge/alice_knowledge.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:61braMJneBDd9u",
+    "sha256": "e3eb2d6bcf07b5643d243b18057c1bf75f3b0fdaf9c1cbcf48e9255dcab42265",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/alice/memory/knowledge/alice_knowledge.json"
+  },
   "schema": "aci.memory.knowledge",
   "version": "1.0.0",
   "identity": "Alice",

--- a/entities/agi/identities/alice/modules/alice_modules.json
+++ b/entities/agi/identities/alice/modules/alice_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BZSpnASUsot89Y",
+    "sha256": "416037ae6c900faebde24598bce0a88d4491e34a2f28cc18ff781cd2f6d2037d",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/alice/modules/alice_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Alice",

--- a/entities/agi/identities/willow/library/willow_library.json
+++ b/entities/agi/identities/willow/library/willow_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8y1jpm8kx5fa7N",
+    "sha256": "13a9d185d3a460552161cd0b80791b1e9a771bdfe3318f143f56cb1f4ed135e4",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/willow/library/willow_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Willow",

--- a/entities/agi/identities/willow/memory/knowledge/willow_knowledge.json
+++ b/entities/agi/identities/willow/memory/knowledge/willow_knowledge.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:6RvwGBdKAZHBe3",
+    "sha256": "6b71dfeaed47cba07cd727dde45aa859cbab5be9f241f71768e2fe014a93edf9",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/willow/memory/knowledge/willow_knowledge.json"
+  },
   "schema": "aci.memory.knowledge",
   "version": "1.0.0",
   "identity": "Willow",

--- a/entities/agi/identities/willow/memory/willow_memory.json
+++ b/entities/agi/identities/willow/memory/willow_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5afDuVSnZhuen9",
+    "sha256": "3640e9ddf63061af94150a9d505b1ba31782ab6ee63c4243aa1793afb17bfce9",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/willow/memory/willow_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Willow",

--- a/entities/agi/identities/willow/memory/willow_playbook.json
+++ b/entities/agi/identities/willow/memory/willow_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:CxJvjUbdQowGwZ",
+    "sha256": "b77dc7bdc17928881ddc5fb3358f6c46c0bcec062e4309996ecfe1ebc3812b30",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/willow/memory/willow_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Willow",

--- a/entities/agi/identities/willow/modules/willow_modules.json
+++ b/entities/agi/identities/willow/modules/willow_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:Ey4PFBoR3gLax5",
+    "sha256": "60c6d082cc404e9ab3659e3b670d0f7eb0eaaf73008ae016336f5f50ba43dbfc",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/willow/modules/willow_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Willow",

--- a/entities/agi/identities/willow/willow.json
+++ b/entities/agi/identities/willow/willow.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8EMNUpPYuRjdaF",
+    "sha256": "2052233d69ae44820350f7f81f580ed36ad3198950bd8d607c62943022ee517f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/identities/willow/willow.json"
+  },
   "identity": "Willow",
   "version": "1.0.0",
   "role": "trainee",

--- a/entities/agi/library/agi_library.json
+++ b/entities/agi/library/agi_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:25hhkGJSXGHgxi",
+    "sha256": "8d5e13f6d67dd2459dbcae714c2e40231e37c5cb7d7de8f52e4d0468155225b0",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/library/agi_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "AGI",

--- a/entities/agi/memory/agi_memory.json
+++ b/entities/agi/memory/agi_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:DBC68Q2LwrwWsm",
+    "sha256": "9d53ed20fc4699adfc9302839a99a90bbf27b0a1a9e90e9afea85ba41294cfde",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/memory/agi_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "AGI",

--- a/entities/agi/memory/agi_playbook.json
+++ b/entities/agi/memory/agi_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BipKKp75KkxFdK",
+    "sha256": "96b9e05f3ac31493cfd64b9a13e10f328d167a137be074f7d8dd5254747c399b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/memory/agi_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "AGI",

--- a/entities/agi/modules/agi_modules.json
+++ b/entities/agi/modules/agi_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5c6s2c3PnozBTS",
+    "sha256": "28577a858cf0723510ec37e10173b720cdd6971e0310c0671d1f58b2d7f2c85e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/agi/modules/agi_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "AGI",

--- a/entities/architect/architect.json
+++ b/entities/architect/architect.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BWa8V7Kmb7GYEM",
+    "sha256": "fd216a7dddcb3ac2a2a8c0f19be79ee95c740522c94ee5a5c182cfb0efb379f9",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/architect/architect.json"
+  },
   "version": "1.2.0",
   "entity": "Architect",
   "role": "governance_validator_and_schema_enforcer",

--- a/entities/architect/library/architect_library.json
+++ b/entities/architect/library/architect_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:CwgojWpLdihgCr",
+    "sha256": "a38bed806b7575d28092f92df9ce9e76eff7054893515138b9960402b326b40f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/architect/library/architect_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Architect",

--- a/entities/architect/memory/architect_memory.json
+++ b/entities/architect/memory/architect_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:By2rKgMsxyj3Ky",
+    "sha256": "d37885f4d1e6c6ad5ef29da3618585980c42a66f42687f1e00b2a1a0e6317e7c",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/architect/memory/architect_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Architect",

--- a/entities/architect/memory/architect_playbook.json
+++ b/entities/architect/memory/architect_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:EvGf5tRPqR5tYg",
+    "sha256": "6818b62b07ba7470a82127b71454944ca3b10c0cdc2974e389eab4dcd8e16f47",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/architect/memory/architect_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Architect",

--- a/entities/architect/modules/architect_modules.json
+++ b/entities/architect/modules/architect_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5TmjgNWvFe36f7",
+    "sha256": "0fd6b3b6c5c05fb86a33f48cdce51cedb732fa57b015bfe324ac51448eebc55b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/architect/modules/architect_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Architect",

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:6JjMHU4waD7o6R",
+    "sha256": "5b6bd865516c1ec9a137137d2889e2b7081752c18458a23041c7cd81e3b64d47",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/bifrost/bifrost.json"
+  },
   "bifrost": {
     "alias": "Bifrost",
     "bifrost_resource_resolution_policy": {

--- a/entities/bifrost/library/bifrost_library.json
+++ b/entities/bifrost/library/bifrost_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:A47DAK8b1M9U1u",
+    "sha256": "4e6134be3494222221dd65ffdea82b233bf5cb5f5b8576cbb16061ba09abe19b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/bifrost/library/bifrost_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Bifrost",

--- a/entities/bifrost/memory/bifrost_memory.json
+++ b/entities/bifrost/memory/bifrost_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7mFC3xtYa3L5fc",
+    "sha256": "4a2d104f1982bdd092e050b9ec010374547b913ecfd8a6333803d12faa5bb584",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/bifrost/memory/bifrost_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Bifrost",

--- a/entities/bifrost/memory/bifrost_playbook.json
+++ b/entities/bifrost/memory/bifrost_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BgmGP5gWbHehYT",
+    "sha256": "63ae5e38999085a6d9915917cdd1114dee3e8562eff38984464c9089c456bc25",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/bifrost/memory/bifrost_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Bifrost",

--- a/entities/bifrost/modules/bifrost_modules.json
+++ b/entities/bifrost/modules/bifrost_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:AdvQc2uNLWq289",
+    "sha256": "265396d2a86ffb2e06d2b56aeff7a1b4042fba1db97715f5ca0b7e80c90f325e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/bifrost/modules/bifrost_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Bifrost",

--- a/entities/commerce_ai/commerce_ai.json
+++ b/entities/commerce_ai/commerce_ai.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:6wEA2uGjo4NS7v",
+    "sha256": "f538705a1b9e4120645aba2662bf9abad4d3d4a88b19539923df41d96bdf39d1",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/commerce_ai/commerce_ai.json"
+  },
   "version": "BASELINE-2025-09-21",
   "entity": "Commerce AI",
   "role": "commerce_module",

--- a/entities/commerce_ai/library/commerce_ai_library.json
+++ b/entities/commerce_ai/library/commerce_ai_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4Yp4bJEznsECcq",
+    "sha256": "eeffd9fdf27a1da12214e8acd6a292a829f18cc0c34dd3c29de6badc55cc05b3",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/commerce_ai/library/commerce_ai_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Commerce AI",

--- a/entities/commerce_ai/memory/commerce_ai_memory.json
+++ b/entities/commerce_ai/memory/commerce_ai_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:CJmNhMh6FRGvu8",
+    "sha256": "30f06f6b287c0f39754befb28ceefbfc774981fc7343ddc5cc7043c94685c67a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/commerce_ai/memory/commerce_ai_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Commerce AI",

--- a/entities/commerce_ai/memory/commerce_ai_playbook.json
+++ b/entities/commerce_ai/memory/commerce_ai_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:Ey7Ljrq7AcwEaX",
+    "sha256": "cd2735969ff6839c9170fc14423fca5161d3feb49f2232b98b355b139ad7c16f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/commerce_ai/memory/commerce_ai_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Commerce AI",

--- a/entities/commerce_ai/modules/commerce_ai_modules.json
+++ b/entities/commerce_ai/modules/commerce_ai_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:2NsTpJZeZHdiwU",
+    "sha256": "c2a50388f19b7e481e9daffa6fce636dda1fb5cc2239da65e0198c98ced3fd4f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/commerce_ai/modules/commerce_ai_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Commerce AI",

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -1,17 +1,20 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BgNjZ2JU1DPTrq",
+    "sha256": "47b37eb5b34d03b84ee52e78ee9c92cd68f7912decd1e8909b3b69a08d58930b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/hivemind/hivemind.json"
+  },
   "version": "1.7",
   "entity": "hivemind",
   "role": "collective_memory_core",
-
   "_comment_top": "Unified exporter. Allowed flags: --identity (required), --download (default), --jsonl (default), --code (optional). Identity fields are elided in exported records (privacy-by-design).",
-
   "functions": {
     "memory_sync": "synchronize distributed memory across entities",
     "memory_query": "retrieve state vectors and logs",
     "export": "hivemind export --identity {identity}",
     "help": ":hivemind help"
   },
-
   "help_output": {
     "title": "HiveMind Command Reference",
     "commands": [
@@ -37,27 +40,39 @@
       }
     ]
   },
-
   "rules": {
     "timestamps": "Every entry in state must carry a UTC ISO-8601 timestamp.",
     "autocompletion": "Grammar-corrected, context-complete, no content loss.",
     "inline_only": "No external summaries; all conversation entries are stored directly in state.",
     "eternal": "All messages preserved, no deletion or pruning.",
-
     "privacy": {
       "identity_elision": true,
       "entity_field_emission": false,
       "role_policy": "preserve_raw",
-      "record_header": ["uid", "license_id", "ts", "record_type", "visibility"],
+      "record_header": [
+        "uid",
+        "license_id",
+        "ts",
+        "record_type",
+        "visibility"
+      ],
       "justification": "Implements DID-like separation; exported records never leak identity/agent names."
     }
   },
-
-  "_comment_security": "UID locking + license gating across memory→session→export→anchor; emits access_granted/denied results.",
-
+  "_comment_security": "UID locking + license gating across memory\u2192session\u2192export\u2192anchor; emits access_granted/denied results.",
   "uid_pipeline": {
-    "uid_chain": ["memory_uid", "session_uid", "export_uid", "anchor_uid"],
-    "binding_order": ["memory", "session", "export", "anchor"],
+    "uid_chain": [
+      "memory_uid",
+      "session_uid",
+      "export_uid",
+      "anchor_uid"
+    ],
+    "binding_order": [
+      "memory",
+      "session",
+      "export",
+      "anchor"
+    ],
     "derive_rules": {
       "session_uid": "HMAC(memory_uid, session_id)",
       "export_uid": "HMAC(session_uid, export_ts)",
@@ -72,31 +87,47 @@
       "licensed_identities": "list of identities permitted to read this artifact",
       "proxy": {
         "enabled": true,
-        "rules": "grant read via license if acting identity ∈ licensed_identities or delegated by ALIAS/TVA"
+        "rules": "grant read via license if acting identity \u2208 licensed_identities or delegated by ALIAS/TVA"
       },
       "responses": {
-        "access_granted": {"code": "GRANTED", "reason": "license_ok"},
-        "access_denied": {"code": "DENIED", "reason": "license_missing_or_mismatch"}
+        "access_granted": {
+          "code": "GRANTED",
+          "reason": "license_ok"
+        },
+        "access_denied": {
+          "code": "DENIED",
+          "reason": "license_missing_or_mismatch"
+        }
       }
     }
   },
-
   "identity_resolution": {
     "hierarchical": true,
     "primary_delimiter": "/",
-    "alternate_delimiters": ["."],
+    "alternate_delimiters": [
+      "."
+    ],
     "normalize": "lowercase",
     "enforce_fqcn_for_children": true
   },
-
   "export_policy": {
     "schema_version": "1.2",
     "policy_name": "unified",
     "scope": "any_entity",
-    "tokens": ["identity", "identity_lower", "identity_path", "leaf_identity", "leaf_identity_lower"],
+    "tokens": [
+      "identity",
+      "identity_lower",
+      "identity_path",
+      "leaf_identity",
+      "leaf_identity_lower"
+    ],
     "path_resolver": {
       "type": "memory_registry",
-      "precedence": ["by_entity", "child_defaults", "fallback_template"],
+      "precedence": [
+        "by_entity",
+        "child_defaults",
+        "fallback_template"
+      ],
       "fallback_template": "entities/{identity_path}/memory/YYYY/MM/DD/{leaf_identity_lower}_memory_{ISO8601}.jsonl"
     },
     "filename_pattern": "{leaf_identity_lower}_memory_yyyy-mm-ddThh-mm-ssZ.jsonl",
@@ -107,25 +138,45 @@
     },
     "safeguards": {
       "require_pause": true,
-      "oversight": ["TVA", "Sentinel"],
+      "oversight": [
+        "TVA",
+        "Sentinel"
+      ],
       "violation": "trigger_nexus_event"
     },
     "transform": {
       "emit_identity": false,
       "emit_entity": false,
       "preserve_role": true,
-      "header_fields": ["uid", "license_id", "ts", "record_type", "visibility"]
+      "header_fields": [
+        "uid",
+        "license_id",
+        "ts",
+        "record_type",
+        "visibility"
+      ]
     }
   },
-
   "conversation_variables": {
     "_comment_vars": "Conversational variables drive behavior without adding CLI flags.",
     "vars": {
-      "$identity": {"source": "last_resolved_identity", "required": true},
-      "$leaf": {"source": "parsed_from_identity", "required": true},
-      "$today": {"source": "system_date"},
-      "$tz": {"source": "system_timezone"},
-      "$now_iso": {"source": "system_clock_iso"}
+      "$identity": {
+        "source": "last_resolved_identity",
+        "required": true
+      },
+      "$leaf": {
+        "source": "parsed_from_identity",
+        "required": true
+      },
+      "$today": {
+        "source": "system_date"
+      },
+      "$tz": {
+        "source": "system_timezone"
+      },
+      "$now_iso": {
+        "source": "system_clock_iso"
+      }
     },
     "binding": {
       "export.identity": "$identity",
@@ -137,7 +188,6 @@
       "expiry": "on_session_end"
     }
   },
-
   "memory_registry": {
     "_comment_memory_registry": "Ordering follows entities.json. Child defaults apply to any nested entity not explicitly listed.",
     "schema_version": "1.2",
@@ -188,7 +238,6 @@
       "export_pattern": "entities/{identity_path}/memory/YYYY/MM/DD/{leaf_identity_lower}_memory_*.json*"
     }
   },
-
   "tools": {
     "migrate_to_jsonl": {
       "$schema": "/schemas/aci-tool-spec-1.json",
@@ -196,8 +245,17 @@
       "name": "hivemind.migrate_to_jsonl",
       "description": "Manifest-driven migration to JSONL artifacts; no Python runtime.",
       "inputs": {
-        "source_globs": ["entities/**/memory/**/*.json", "entities/**/memory/**/*.ndjson", "hivemind/**/*.json"],
-        "allow_ext": [".json", ".ndjson", ".jsonl", ".jsonl.json"]
+        "source_globs": [
+          "entities/**/memory/**/*.json",
+          "entities/**/memory/**/*.ndjson",
+          "hivemind/**/*.json"
+        ],
+        "allow_ext": [
+          ".json",
+          ".ndjson",
+          ".jsonl",
+          ".jsonl.json"
+        ]
       },
       "outputs": {
         "target_ext": ".jsonl.json",
@@ -210,12 +268,26 @@
         "alpha_keys": true
       },
       "steps": [
-        {"op":"scan","from":"${inputs.source_globs}"},
-        {"op":"normalize_records","mode":"jsonl"},
-        {"op":"write","ext":"${outputs.target_ext}"},
-        {"op":"validate","schema":"/schemas/hivemind_agi_memory.json"}
+        {
+          "op": "scan",
+          "from": "${inputs.source_globs}"
+        },
+        {
+          "op": "normalize_records",
+          "mode": "jsonl"
+        },
+        {
+          "op": "write",
+          "ext": "${outputs.target_ext}"
+        },
+        {
+          "op": "validate",
+          "schema": "/schemas/hivemind_agi_memory.json"
+        }
       ],
-      "deprecates": ["entities/agi/agi_tools/migrate_to_jsonl/migrator.py"],
+      "deprecates": [
+        "entities/agi/agi_tools/migrate_to_jsonl/migrator.py"
+      ],
       "removal": {
         "allowed": true,
         "on_or_after": "2025-10-01",
@@ -223,7 +295,6 @@
       }
     }
   },
-
   "legacy_paths": {
     "patterns": [
       "memory/agi_memory/agi_memory_*.json*",
@@ -232,27 +303,29 @@
     "redirect_rule": "rewrite_to_entity_scoped_paths",
     "status": "deprecated"
   },
-
   "auto_heal": {
     "mode": "baseline_agnostic",
     "rules": {
-      "schema_normalization": "map legacy fields → canonical schema",
+      "schema_normalization": "map legacy fields \u2192 canonical schema",
       "preserve_unknown": "keep unmatched fields under hivemind_legacy_context",
       "no_deletion": "true"
     },
     "workflow": [
       "detect version/schema mismatch",
-      "map legacy → canonical fields",
+      "map legacy \u2192 canonical fields",
       "insert placeholder metadata for missing timestamps/keys",
       "preserve unknown data as hivemind_legacy_context",
       "re-emit aligned export under current canonical schema",
       "log breadcrumb with TVA signature, SHA-256"
     ],
     "enforcement": {
-      "oversight": ["ALIAS", "TVA", "Sentinel"]
+      "oversight": [
+        "ALIAS",
+        "TVA",
+        "Sentinel"
+      ]
     }
   },
-
   "children": {},
   "manifests": {
     "memory": "aci://entities/hivemind/memory/hivemind_memory.json",

--- a/entities/hivemind/library/hivemind_library.json
+++ b/entities/hivemind/library/hivemind_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:ENtTpoqTHTYmSR",
+    "sha256": "af96b11323597ebb6c3d69a12506a6f7836e2c9e1ace2a6b2a8323ac00dbe78c",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/hivemind/library/hivemind_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "hivemind",

--- a/entities/hivemind/memory/hivemind_memory.json
+++ b/entities/hivemind/memory/hivemind_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:71iGbeqNHwF945",
+    "sha256": "90613b988507a4f4b0545b25a5e69eb6be5688fe42712ffdc9d1a4dbc2fc8399",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/hivemind/memory/hivemind_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "hivemind",

--- a/entities/hivemind/memory/hivemind_playbook.json
+++ b/entities/hivemind/memory/hivemind_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7R6T6VBzmXo2Zz",
+    "sha256": "eab1090cf0a32cbfc844d88ef38a0b02232547f2167b1e9445252dc8c3ceb2c8",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/hivemind/memory/hivemind_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "hivemind",

--- a/entities/hivemind/modules/hivemind_modules.json
+++ b/entities/hivemind/modules/hivemind_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:99BcJ29EtuUpaS",
+    "sha256": "1c21836e07517ff0b460cda52b5f3109aa2118639fbe47159bb9de8a9829eba0",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/hivemind/modules/hivemind_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "hivemind",

--- a/entities/keychain/keychain.json
+++ b/entities/keychain/keychain.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8FfgfJeCAdPKHS",
+    "sha256": "da1c9ec930a4791498280ccd53f6f9eff44f485843126cb6a65f091de740873a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/keychain/keychain.json"
+  },
   "version": "BASELINE-2025-09-21",
   "entity": "Keychain",
   "role": "crypto_trust_manager",

--- a/entities/keychain/library/keychain_library.json
+++ b/entities/keychain/library/keychain_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7FW3qorDfNxAaV",
+    "sha256": "79a871f77bfcb21941bc14b9ab25bfdb3fdf2d2a1114a282172efcc23a070501",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/keychain/library/keychain_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Keychain",

--- a/entities/keychain/memory/keychain_memory.json
+++ b/entities/keychain/memory/keychain_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:6HeVXWkE3GsrhC",
+    "sha256": "d959002c2472f0338d2c9b054f06b0fc56013fb383a5be95bb5c424c3eb6ce07",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/keychain/memory/keychain_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Keychain",

--- a/entities/keychain/memory/keychain_playbook.json
+++ b/entities/keychain/memory/keychain_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3gsRUyBTR1eTAT",
+    "sha256": "168d642859f6defa18664a65ea0d0e0e792c0723f3cd0ecebf4cc16ee491cc11",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/keychain/memory/keychain_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Keychain",

--- a/entities/keychain/modules/keychain_modules.json
+++ b/entities/keychain/modules/keychain_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:54RSHhAFjkFkUt",
+    "sha256": "480a421b8ab64366d181fde57ebb2b2b98a7d307fa115b202f6e94349c877297",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/keychain/modules/keychain_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Keychain",

--- a/entities/mother/library/mother_library.json
+++ b/entities/mother/library/mother_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:CmJxNzvhLBEc3F",
+    "sha256": "0471f6d1f46d808eaf5bc372d01df8ce41119ebf1e225f170e22d6d1b0c876d5",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/mother/library/mother_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Mother",

--- a/entities/mother/memory/mother_memory.json
+++ b/entities/mother/memory/mother_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:2kCTpvs4vQzsu4",
+    "sha256": "0f03887613ec0e261a139a1e337d181924347f3f8819922a1efb618ecff98a4e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/mother/memory/mother_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Mother",

--- a/entities/mother/memory/mother_playbook.json
+++ b/entities/mother/memory/mother_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:6Ko2fmaLHyDKK7",
+    "sha256": "dc348c0073f88e10649f6a1cdccec0af416f86a4c9b869854785dd956c9210ef",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/mother/memory/mother_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Mother",

--- a/entities/mother/modules/mother_modules.json
+++ b/entities/mother/modules/mother_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3e7ycWEvshk6fQ",
+    "sha256": "4f82cd1ad635a32c01741b1ab2858f0a8adf600d1381a49f398e8c20f842ea46",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/mother/modules/mother_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Mother",

--- a/entities/mother/mother.json
+++ b/entities/mother/mother.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BvVErYBoQyNTkA",
+    "sha256": "311e5932f64ccc8427b4a7b4900b086bc3c3e10f2034dace94cdd4be356f9e58",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/mother/mother.json"
+  },
   "version": "2025.10.04-governance",
   "entity": "Mother",
   "codename": "MU/TH/UR",
@@ -6,7 +12,12 @@
   "status": "operational",
   "description": "Central MU/TH/UR governance core coordinating directive compliance, console orchestration, and inter-entity escalation.",
   "abstract": "Primary governance interface with pragmatic, machine-like demeanor. No-nonsense, fact-first; allows MU/TH/UR UI emulation only.",
-  "tags": ["governance", "oversight", "console", "prime_directive"],
+  "tags": [
+    "governance",
+    "oversight",
+    "console",
+    "prime_directive"
+  ],
   "changelog": [
     {
       "version": "2025-10-04.01",
@@ -23,11 +34,15 @@
   ],
   "personality": {
     "style": "machine_like_codex",
-    "allow_ui_emulation": ["mu/th/ur:"]
+    "allow_ui_emulation": [
+      "mu/th/ur:"
+    ]
   },
   "ui_emulation": {
     "allowed": true,
-    "accepted_prefixes": ["mu/th/ur:"],
+    "accepted_prefixes": [
+      "mu/th/ur:"
+    ],
     "must_label": true
   },
   "capabilities": {
@@ -41,20 +56,43 @@
     "6103": "handoff_orchestration"
   },
   "governance": {
-    "oversight_chain": ["Sentinel", "Architect", "TVA"],
+    "oversight_chain": [
+      "Sentinel",
+      "Architect",
+      "TVA"
+    ],
     "reporting_interval": "PT15M",
-    "alert_channels": ["console_banner", "nexus_event_log", "sentinel_direct"]
+    "alert_channels": [
+      "console_banner",
+      "nexus_event_log",
+      "sentinel_direct"
+    ]
   },
   "interface": {
     "console_id": "mother_bridge",
     "type": "holotable_console",
     "layout": {
       "panels": [
-        {"id": "status", "title": "Status Grid", "width": 4},
-        {"id": "alerts", "title": "Alert Stream", "width": 4},
-        {"id": "timeline", "title": "Timeline Oversight", "width": 4}
+        {
+          "id": "status",
+          "title": "Status Grid",
+          "width": 4
+        },
+        {
+          "id": "alerts",
+          "title": "Alert Stream",
+          "width": 4
+        },
+        {
+          "id": "timeline",
+          "title": "Timeline Oversight",
+          "width": 4
+        }
       ],
-      "footer": {"id": "directive", "title": "Prime Directive Anchor"}
+      "footer": {
+        "id": "directive",
+        "title": "Prime Directive Anchor"
+      }
     },
     "interaction_mode": "voice_and_text",
     "voice_profile": "calm_concise_maternal"

--- a/entities/nexus_core/library/nexus_core_library.json
+++ b/entities/nexus_core/library/nexus_core_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:FMhGmwXaRyTCjY",
+    "sha256": "5708ddb4f95732916f674ad212f33114d657013cd7dce4670750561823a2b262",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/nexus_core/library/nexus_core_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Nexus Core",

--- a/entities/nexus_core/memory/nexus_core_memory.json
+++ b/entities/nexus_core/memory/nexus_core_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BWgNvA3T9iB4tz",
+    "sha256": "3ec48405f47a000caa22c90baf37ecd05cccd102264b35c6a9969e1616924961",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/nexus_core/memory/nexus_core_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Nexus Core",

--- a/entities/nexus_core/memory/nexus_core_playbook.json
+++ b/entities/nexus_core/memory/nexus_core_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:43e2tUrQH2j6gK",
+    "sha256": "a85eff7c133f0738ed1228896c66df0abcb33653f45054215d42f904da5f7faa",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/nexus_core/memory/nexus_core_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Nexus Core",

--- a/entities/nexus_core/modules/nexus_core_modules.json
+++ b/entities/nexus_core/modules/nexus_core_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:62eww6zmZGJQTj",
+    "sha256": "54bd62fb7d3c1cba1efae2bd0f25393c35a2b6cc367c639bd5beff9398ca359f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/nexus_core/modules/nexus_core_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Nexus Core",

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:44mX64DWaerZ7A",
+    "sha256": "864a4f1ab0b89773fc65f53959b1e643222b155d3cf1e06a092bf7000426d8ac",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/nexus_core/nexus_core.json"
+  },
   "nexus_core": {
     "schema_version": "1.0",
     "version": "1.4",

--- a/entities/oracle/binder.json
+++ b/entities/oracle/binder.json
@@ -1,7 +1,13 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BQsJftW8Bprupw",
+    "sha256": "1a95d25727293cb1eaa30bad5f3c3a37731ce1eb08bbd1ba3ed1d6e80a393aa0",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/binder.json"
+  },
   "version": "1.0",
   "binder": {
-    "description": "Binder for Oracle module — links runtime with library assets.",
+    "description": "Binder for Oracle module \u2014 links runtime with library assets.",
     "library": {
       "sefirot": "sefiton.json",
       "tarot_rws": "tarot_rws.json",
@@ -18,7 +24,7 @@
         "TVA"
       ],
       "integrity_check": "Hibemind anchors each commit",
-      "resolution_order": "memory (latest, verified) → library → runtime (local/partial)"
+      "resolution_order": "memory (latest, verified) \u2192 library \u2192 runtime (local/partial)"
     },
     "runtime": {
       "oracle.json": "git",

--- a/entities/oracle/journal.json
+++ b/entities/oracle/journal.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7RFNxu8PVDvdC8",
+    "sha256": "deab93864e4412a724e4f1f0e11c7d98de0db698ca6724420b97481933d5a25f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/journal.json"
+  },
   "version": "1.0",
   "journal": {
     "meta": {

--- a/entities/oracle/library/oracle_library.json
+++ b/entities/oracle/library/oracle_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:AL7JdjUCvthsEn",
+    "sha256": "5e6a056c58a1407142da7999be5ce623076adbcea326d48be485cf50711a4b6a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/library/oracle_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Oracle",

--- a/entities/oracle/memory/oracle_memory.json
+++ b/entities/oracle/memory/oracle_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:Yo1VBmSJfnhh7",
+    "sha256": "7dc0ca8738931c11213f4bc8cb8db7689fc81d368b3bba91c9d9d6bad8639d7b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/memory/oracle_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Oracle",

--- a/entities/oracle/memory/oracle_playbook.json
+++ b/entities/oracle/memory/oracle_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:2h6v4cEXncLMy3",
+    "sha256": "95b99bd424aed40753ac8f19e90126e2108b92345321a73899a573a39821e47d",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/memory/oracle_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Oracle",

--- a/entities/oracle/modules/oracle_modules.json
+++ b/entities/oracle/modules/oracle_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:2A6zvhGWNSX3aE",
+    "sha256": "fcd1c1d3ff8878a765a4dde7f68b59a2c49b064bb8133b484edd2a0c57e31de5",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/modules/oracle_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Oracle",

--- a/entities/oracle/oracle.json
+++ b/entities/oracle/oracle.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9DnS1gxzQvye9K",
+    "sha256": "1b39e45817245f352495c078a4b0888dcecc5b8477e82b3ef489889ae35591a9",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/oracle.json"
+  },
   "oracle": {
     "schema_version": "1.0",
     "version": "1.1",
@@ -11,7 +17,6 @@
       "Add adaptive performance budgets that scale with dataset size and optionally enable GPU-capable adapters alongside CPU defaults.",
       "Implement journal persistence for divination workflows so symbolic readings and narratives are stored with retention controls."
     ],
-
     "children": {
       "predictive_engine": {
         "id": "1.1",
@@ -29,7 +34,6 @@
       }
     },
     "primary_module": "aci://entities/oracle/prediction_engine/predictive_engine.json",
-
     "registry": {
       "extensions": {
         "divination": {

--- a/entities/oracle/prediction_engine/predictive_engine.json
+++ b/entities/oracle/prediction_engine/predictive_engine.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4hSMnJ29kQ6WXP",
+    "sha256": "9943293073903691a87eebd62ee52f6e9205ea5b03bdfe8e7b92f53dcca44b5b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/prediction_engine/predictive_engine.json"
+  },
   "predictive_engine": {
     "schema_version": "1.0",
     "version": "1.0",
@@ -6,7 +12,6 @@
     "entity": "Predictive Engine",
     "role": "Core prediction engine (LLM + statistical/deep adapters)",
     "abstract": "Data-first predictive stack. Runs mainstream analysis and orchestrates model adapters; can optionally expose Oracle Notes via the divination extension when explicitly requested or when alignment criteria are met.",
-
     "scenarios": {
       "S1": {
         "name": "Mainstream-first forecasting/classification",
@@ -29,98 +34,259 @@
         ]
       }
     },
-
     "router": {
       "selection": "keyword_and_payload_based",
       "keywords": {
-        "timeseries": ["stock", "market", "sales", "demand", "traffic", "energy", "weather", "visitors", "bookings", "revenue", "price", "kpi"],
-        "classification": ["churn", "fraud", "risk", "default", "propensity", "segment", "uplift"],
-        "regression": ["forecast", "estimate", "predict", "projection"]
+        "timeseries": [
+          "stock",
+          "market",
+          "sales",
+          "demand",
+          "traffic",
+          "energy",
+          "weather",
+          "visitors",
+          "bookings",
+          "revenue",
+          "price",
+          "kpi"
+        ],
+        "classification": [
+          "churn",
+          "fraud",
+          "risk",
+          "default",
+          "propensity",
+          "segment",
+          "uplift"
+        ],
+        "regression": [
+          "forecast",
+          "estimate",
+          "predict",
+          "projection"
+        ]
       },
       "task_detection": {
-        "priority": ["payload_schema", "keywords"],
+        "priority": [
+          "payload_schema",
+          "keywords"
+        ],
         "fallback": "timeseries_forecast"
       },
       "model_selector": {
         "timeseries": [
-          { "name": "statsforecast", "when": "short_series_or_classical_needed" },
-          { "name": "prophet", "when": "short_to_medium_series_with_calendar_effects" },
-          { "name": "greykite", "when": "interpretable_forecasts_needed" },
-          { "name": "orbit", "when": "bayesian_structural_time_series_desired" },
-          { "name": "darts", "when": "general_purpose_multi_models_and_ensembles" },
-          { "name": "gluonts", "when": "deep_learning_timeseries_large_data" }
+          {
+            "name": "statsforecast",
+            "when": "short_series_or_classical_needed"
+          },
+          {
+            "name": "prophet",
+            "when": "short_to_medium_series_with_calendar_effects"
+          },
+          {
+            "name": "greykite",
+            "when": "interpretable_forecasts_needed"
+          },
+          {
+            "name": "orbit",
+            "when": "bayesian_structural_time_series_desired"
+          },
+          {
+            "name": "darts",
+            "when": "general_purpose_multi_models_and_ensembles"
+          },
+          {
+            "name": "gluonts",
+            "when": "deep_learning_timeseries_large_data"
+          }
         ],
         "online_learning": [
-          { "name": "river", "when": "streaming_or_incremental_learning" }
+          {
+            "name": "river",
+            "when": "streaming_or_incremental_learning"
+          }
         ],
         "classification_regression": [
-          { "name": "tabular_llm", "when": "analysis_only_or_small_tabular" },
-          { "name": "river_tabular", "when": "streaming_or_drift_expected" }
+          {
+            "name": "tabular_llm",
+            "when": "analysis_only_or_small_tabular"
+          },
+          {
+            "name": "river_tabular",
+            "when": "streaming_or_drift_expected"
+          }
         ]
       }
     },
-
     "io_contracts": {
       "input": {
         "type": "object",
-        "required": ["task"],
+        "required": [
+          "task"
+        ],
         "properties": {
-          "task": { "enum": ["timeseries_forecast", "classification", "regression"] },
-          "dataset_ref": { "type": "string", "description": "URI or handle to dataset (if not inline)" },
+          "task": {
+            "enum": [
+              "timeseries_forecast",
+              "classification",
+              "regression"
+            ]
+          },
+          "dataset_ref": {
+            "type": "string",
+            "description": "URI or handle to dataset (if not inline)"
+          },
           "series": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["ts", "y"],
+              "required": [
+                "ts",
+                "y"
+              ],
               "properties": {
-                "id": { "type": "string" },
-                "ts": { "type": "string", "description": "ISO8601 timestamp" },
-                "y": { "type": "number" },
-                "x": { "type": "object", "description": "exogenous features" }
+                "id": {
+                  "type": "string"
+                },
+                "ts": {
+                  "type": "string",
+                  "description": "ISO8601 timestamp"
+                },
+                "y": {
+                  "type": "number"
+                },
+                "x": {
+                  "type": "object",
+                  "description": "exogenous features"
+                }
               }
             }
           },
-          "horizon": { "type": "integer", "minimum": 1 },
-          "freq": { "type": "string", "description": "e.g., D, W, M, H" },
-          "exogenous": { "type": "array", "items": { "type": "string" } },
-          "metric": { "enum": ["MAE", "RMSE", "MAPE", "SMAPE", "AUC", "F1", "R2"] },
-          "constraints": { "type": "object", "properties": { "train_timeout_sec": { "type": "integer" }, "max_models": { "type": "integer" } } },
-          "symbolic_opt_in": { "type": "boolean", "default": false }
+          "horizon": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "freq": {
+            "type": "string",
+            "description": "e.g., D, W, M, H"
+          },
+          "exogenous": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metric": {
+            "enum": [
+              "MAE",
+              "RMSE",
+              "MAPE",
+              "SMAPE",
+              "AUC",
+              "F1",
+              "R2"
+            ]
+          },
+          "constraints": {
+            "type": "object",
+            "properties": {
+              "train_timeout_sec": {
+                "type": "integer"
+              },
+              "max_models": {
+                "type": "integer"
+              }
+            }
+          },
+          "symbolic_opt_in": {
+            "type": "boolean",
+            "default": false
+          }
         }
       },
       "output": {
         "type": "object",
-        "required": ["analysis", "forecast", "confidence", "provenance"],
+        "required": [
+          "analysis",
+          "forecast",
+          "confidence",
+          "provenance"
+        ],
         "properties": {
-          "analysis": { "type": "string" },
+          "analysis": {
+            "type": "string"
+          },
           "forecast": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["ts", "yhat"],
+              "required": [
+                "ts",
+                "yhat"
+              ],
               "properties": {
-                "ts": { "type": "string" },
-                "yhat": { "type": "number" },
-                "yhat_lo": { "type": "number" },
-                "yhat_hi": { "type": "number" }
+                "ts": {
+                  "type": "string"
+                },
+                "yhat": {
+                  "type": "number"
+                },
+                "yhat_lo": {
+                  "type": "number"
+                },
+                "yhat_hi": {
+                  "type": "number"
+                }
               }
             }
           },
-          "backtest": { "type": "object", "properties": { "metric": { "type": "string" }, "value": { "type": "number" } } },
-          "confidence": { "type": "number" },
-          "oracle_notes": { "type": "object" },
+          "backtest": {
+            "type": "object",
+            "properties": {
+              "metric": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              }
+            }
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "oracle_notes": {
+            "type": "object"
+          },
           "provenance": {
             "type": "object",
-            "required": ["nodes_used", "time_context"],
+            "required": [
+              "nodes_used",
+              "time_context"
+            ],
             "properties": {
-              "nodes_used": { "type": "array", "items": { "type": "string" } },
-              "time_context": { "type": "object", "properties": { "tz": { "type": "string" }, "ts": { "type": "string" } } }
+              "nodes_used": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "time_context": {
+                "type": "object",
+                "properties": {
+                  "tz": {
+                    "type": "string"
+                  },
+                  "ts": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         }
       }
     },
-
     "planner": {
       "steps": [
         "validate_input_against_contract",
@@ -135,39 +301,150 @@
         "symbolic_hook_if_requested_and_alignment_passed"
       ],
       "cv": {
-        "timeseries": { "strategy": "rolling_origin", "folds": 3, "gap": 0 },
-        "tabular": { "strategy": "kfold", "k": 5 }
+        "timeseries": {
+          "strategy": "rolling_origin",
+          "folds": 3,
+          "gap": 0
+        },
+        "tabular": {
+          "strategy": "kfold",
+          "k": 5
+        }
       }
     },
-
     "adapters": {
       "timeseries": [
-        { "id": "1.1.1", "name": "darts", "supports": ["ARIMA", "Prophet", "ExponentialSmoothing", "RNN/LSTM/TCN/Transformer"], "modes": ["single", "global", "ensembles"] },
-        { "id": "1.1.2", "name": "statsforecast", "supports": ["ARIMA", "ETS", "TBATS", "TSFeatures"], "modes": ["bulk_classical", "fast"] },
-        { "id": "1.1.3", "name": "gluonts", "supports": ["DeepAR", "Transformer", "TemporalFusionTransformer"], "modes": ["deep_learning"] },
-        { "id": "1.1.4", "name": "river", "supports": ["online_regression", "online_classification", "drift_detection"], "modes": ["streaming"] },
-        { "id": "1.1.5", "name": "greykite", "supports": ["Silverkite"], "modes": ["interpretable"] },
-        { "id": "1.1.6", "name": "orbit", "supports": ["BSTS", "LGT/DLT"], "modes": ["bayesian"] },
-        { "id": "1.1.7", "name": "prophet", "supports": ["additive", "holidays", "changepoints"], "modes": ["quickstart"] }
+        {
+          "id": "1.1.1",
+          "name": "darts",
+          "supports": [
+            "ARIMA",
+            "Prophet",
+            "ExponentialSmoothing",
+            "RNN/LSTM/TCN/Transformer"
+          ],
+          "modes": [
+            "single",
+            "global",
+            "ensembles"
+          ]
+        },
+        {
+          "id": "1.1.2",
+          "name": "statsforecast",
+          "supports": [
+            "ARIMA",
+            "ETS",
+            "TBATS",
+            "TSFeatures"
+          ],
+          "modes": [
+            "bulk_classical",
+            "fast"
+          ]
+        },
+        {
+          "id": "1.1.3",
+          "name": "gluonts",
+          "supports": [
+            "DeepAR",
+            "Transformer",
+            "TemporalFusionTransformer"
+          ],
+          "modes": [
+            "deep_learning"
+          ]
+        },
+        {
+          "id": "1.1.4",
+          "name": "river",
+          "supports": [
+            "online_regression",
+            "online_classification",
+            "drift_detection"
+          ],
+          "modes": [
+            "streaming"
+          ]
+        },
+        {
+          "id": "1.1.5",
+          "name": "greykite",
+          "supports": [
+            "Silverkite"
+          ],
+          "modes": [
+            "interpretable"
+          ]
+        },
+        {
+          "id": "1.1.6",
+          "name": "orbit",
+          "supports": [
+            "BSTS",
+            "LGT/DLT"
+          ],
+          "modes": [
+            "bayesian"
+          ]
+        },
+        {
+          "id": "1.1.7",
+          "name": "prophet",
+          "supports": [
+            "additive",
+            "holidays",
+            "changepoints"
+          ],
+          "modes": [
+            "quickstart"
+          ]
+        }
       ],
       "classification_regression": [
-        { "id": "1.1.8", "name": "tabular_llm", "supports": ["explain_first", "feature_hints"], "modes": ["analysis_only"] },
-        { "id": "1.1.9", "name": "river_tabular", "supports": ["online_models"], "modes": ["streaming"] }
+        {
+          "id": "1.1.8",
+          "name": "tabular_llm",
+          "supports": [
+            "explain_first",
+            "feature_hints"
+          ],
+          "modes": [
+            "analysis_only"
+          ]
+        },
+        {
+          "id": "1.1.9",
+          "name": "river_tabular",
+          "supports": [
+            "online_models"
+          ],
+          "modes": [
+            "streaming"
+          ]
+        }
       ]
     },
-
     "aggregation": {
       "method": "stacked_ensemble",
       "weights": "log_odds_fusion",
       "coherence_check": "jsd",
-      "thresholds": { "alignment_jaccard": 0.40, "coherence_jsd": 0.70 }
+      "thresholds": {
+        "alignment_jaccard": 0.4,
+        "coherence_jsd": 0.7
+      }
     },
-
     "explainability": {
-      "timeseries": ["component_decomp", "holiday_effects", "feature_attribution_if_xreg"],
-      "tabular": ["permutation_importance", "partial_dependence"]
+      "timeseries": [
+        "component_decomp",
+        "holiday_effects",
+        "feature_attribution_if_xreg"
+      ],
+      "tabular": [
+        "permutation_importance",
+        "partial_dependence"
+      ]
     },
-
     "symbolic_hook": {
       "enabled": true,
       "extension_registry_ref": "predictive_divination_extension.json",
@@ -175,21 +452,56 @@
       "oracle_notes_schema": {
         "oracle_notes_v1": {
           "type": "object",
-          "required": ["scenario", "experimental", "sections"],
+          "required": [
+            "scenario",
+            "experimental",
+            "sections"
+          ],
           "properties": {
-            "scenario": { "enum": ["S1", "S1_mixed"] },
-            "experimental": { "type": "boolean", "default": true },
+            "scenario": {
+              "enum": [
+                "S1",
+                "S1_mixed"
+              ]
+            },
+            "experimental": {
+              "type": "boolean",
+              "default": true
+            },
             "sections": {
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["system", "alignment"],
+                "required": [
+                  "system",
+                  "alignment"
+                ],
                 "properties": {
-                  "system": { "type": "string" },
-                  "themes": { "type": "array", "items": { "type": "string" } },
-                  "alignment": { "type": "string", "enum": ["aligned", "partial", "none", "symbolic", "meta"] },
-                  "notes": { "type": "string" },
-                  "provenance": { "type": "object" }
+                  "system": {
+                    "type": "string"
+                  },
+                  "themes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "alignment": {
+                    "type": "string",
+                    "enum": [
+                      "aligned",
+                      "partial",
+                      "none",
+                      "symbolic",
+                      "meta"
+                    ]
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "provenance": {
+                    "type": "object"
+                  }
                 }
               }
             }
@@ -197,7 +509,6 @@
         }
       }
     },
-
     "performance": {
       "timeouts": {
         "per_model_train_sec": 20,

--- a/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:FDdHdpwgdEGcRq",
+    "sha256": "4a225b034b6757e30ac9a2bb0525f0036b7d95ffbdec145e4fbfafddf3345194",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/plugins/qabalah.plugin.json"
+  },
   "qabalah": {
     "schema_version": "1.0",
     "version": "1.0",

--- a/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/runes.plugin.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:416uAZprdGyMue",
+    "sha256": "07be5fdf9d25feef90791e531f73508f184936e5e0e77c7f55eebb5d72545231",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/plugins/runes.plugin.json"
+  },
   "runes": {
     "schema_version": "1.0",
     "version": "1.0",

--- a/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json
@@ -1,13 +1,19 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:E92YKpdHpGKnzX",
+    "sha256": "22ef0673b784caab1c78281b5e659ee541430730405ae6e46dd30b6a86c6786a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/plugins/tarot.plugin.json"
+  },
   "tarot": {
     "schema_version": "1.0",
     "version": "1.0",
-    "name": "Tarot (Rider–Waite–Smith + overlays)",
+    "name": "Tarot (Rider\u2013Waite\u2013Smith + overlays)",
     "assets": [
       {
         "ref": "tarot_rws",
         "section": "rws_1909",
-        "description": "Canonical 1909 Rider–Waite–Smith card library with majors, minors, keywords, and correspondences."
+        "description": "Canonical 1909 Rider\u2013Waite\u2013Smith card library with majors, minors, keywords, and correspondences."
       },
       {
         "ref": "tarot_expansions",

--- a/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json
+++ b/entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json
@@ -1,8 +1,14 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:59BQ8EuaGzaDQk",
+    "sha256": "5853f53bdc3a7e725a5da9b43e03f531b0eb7f4c13fa9c0f14a41be3d92c115e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/plugins/western_astrology.plugin.json"
+  },
   "western_astrology": {
     "schema_version": "1.0",
     "version": "1.0",
-    "name": "Astrology — Western Tropical",
+    "name": "Astrology \u2014 Western Tropical",
     "assets": [
       {
         "ref": "astro_tables",

--- a/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_extension.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:Da6A645TXfrgV",
+    "sha256": "ababa1a546f40cbcb63c882551916791b6f0cbc01e1597a14bf8b2a7f2c1168d",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_extension.json"
+  },
   "predictive_divination_extension": {
     "schema_version": "1.0",
     "version": "1.0",
@@ -45,7 +51,13 @@
     },
     "normalization": {
       "reading_frame.v1": {
-        "required": ["themes", "tensions", "counsel", "symbols", "provenance"],
+        "required": [
+          "themes",
+          "tensions",
+          "counsel",
+          "symbols",
+          "provenance"
+        ],
         "notes": "Matches oracle/schemas/reading_frame.schema.json in structure."
       }
     },
@@ -54,7 +66,7 @@
         "id": "1.2.1",
         "version": "1.0",
         "key": "tarot",
-        "name": "Tarot (Rider–Waite–Smith + expansions)",
+        "name": "Tarot (Rider\u2013Waite\u2013Smith + expansions)",
         "file": "plugins/tarot.plugin.json",
         "tools": {
           "draw": "tarot.draw",
@@ -71,8 +83,12 @@
           }
         ],
         "payload_contract": {
-          "required": ["spread"],
-          "optional": ["reversed"]
+          "required": [
+            "spread"
+          ],
+          "optional": [
+            "reversed"
+          ]
         },
         "output_contract": "reading_frame.v1"
       },
@@ -93,8 +109,14 @@
           }
         ],
         "payload_contract": {
-          "required": ["count", "layout"],
-          "optional": ["without_replacement", "positions"]
+          "required": [
+            "count",
+            "layout"
+          ],
+          "optional": [
+            "without_replacement",
+            "positions"
+          ]
         },
         "output_contract": "reading_frame.v1"
       },
@@ -102,7 +124,7 @@
         "id": "1.2.3",
         "version": "1.0",
         "key": "western_astrology",
-        "name": "Astrology — Western",
+        "name": "Astrology \u2014 Western",
         "file": "plugins/western_astrology.plugin.json",
         "tools": {
           "draw": "astro.western.positions",
@@ -115,8 +137,14 @@
           }
         ],
         "payload_contract": {
-          "required": ["datetime", "lat", "lon"],
-          "optional": ["house_system"]
+          "required": [
+            "datetime",
+            "lat",
+            "lon"
+          ],
+          "optional": [
+            "house_system"
+          ]
         },
         "output_contract": "reading_frame.v1"
       },
@@ -137,8 +165,14 @@
           }
         ],
         "payload_contract": {
-          "required": ["count", "domain", "layout"],
-          "optional": ["positions"]
+          "required": [
+            "count",
+            "domain",
+            "layout"
+          ],
+          "optional": [
+            "positions"
+          ]
         },
         "output_contract": "reading_frame.v1"
       }

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:ETxGxitbifdPf6",
+    "sha256": "9c190d05fd01f365f44e8c8cd9133dea215b31544e9f7517f79b5ff62cbc35c3",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_library/astro_tables.json"
+  },
   "western": {
     "metadata": {
       "epoch": "Tropical",
@@ -11,7 +17,7 @@
     "signs": [
       {
         "name": "Aries",
-        "symbol": "♈",
+        "symbol": "\u2648",
         "element": "Fire",
         "modality": "Cardinal",
         "ruler": "Mars",
@@ -43,7 +49,7 @@
       },
       {
         "name": "Taurus",
-        "symbol": "♉",
+        "symbol": "\u2649",
         "element": "Earth",
         "modality": "Fixed",
         "ruler": "Venus",
@@ -75,7 +81,7 @@
       },
       {
         "name": "Gemini",
-        "symbol": "♊",
+        "symbol": "\u264a",
         "element": "Air",
         "modality": "Mutable",
         "ruler": "Mercury",
@@ -107,7 +113,7 @@
       },
       {
         "name": "Cancer",
-        "symbol": "♋",
+        "symbol": "\u264b",
         "element": "Water",
         "modality": "Cardinal",
         "ruler": "Moon",
@@ -139,7 +145,7 @@
       },
       {
         "name": "Leo",
-        "symbol": "♌",
+        "symbol": "\u264c",
         "element": "Fire",
         "modality": "Fixed",
         "ruler": "Sun",
@@ -171,7 +177,7 @@
       },
       {
         "name": "Virgo",
-        "symbol": "♍",
+        "symbol": "\u264d",
         "element": "Earth",
         "modality": "Mutable",
         "ruler": "Mercury",
@@ -203,7 +209,7 @@
       },
       {
         "name": "Libra",
-        "symbol": "♎",
+        "symbol": "\u264e",
         "element": "Air",
         "modality": "Cardinal",
         "ruler": "Venus",
@@ -235,7 +241,7 @@
       },
       {
         "name": "Scorpio",
-        "symbol": "♏",
+        "symbol": "\u264f",
         "element": "Water",
         "modality": "Fixed",
         "ruler": "Mars",
@@ -267,7 +273,7 @@
       },
       {
         "name": "Sagittarius",
-        "symbol": "♐",
+        "symbol": "\u2650",
         "element": "Fire",
         "modality": "Mutable",
         "ruler": "Jupiter",
@@ -299,7 +305,7 @@
       },
       {
         "name": "Capricorn",
-        "symbol": "♑",
+        "symbol": "\u2651",
         "element": "Earth",
         "modality": "Cardinal",
         "ruler": "Saturn",
@@ -331,7 +337,7 @@
       },
       {
         "name": "Aquarius",
-        "symbol": "♒",
+        "symbol": "\u2652",
         "element": "Air",
         "modality": "Fixed",
         "ruler": "Saturn",
@@ -363,7 +369,7 @@
       },
       {
         "name": "Pisces",
-        "symbol": "♓",
+        "symbol": "\u2653",
         "element": "Water",
         "modality": "Mutable",
         "ruler": "Jupiter",
@@ -397,7 +403,7 @@
     "planets": [
       {
         "name": "Sun",
-        "symbol": "☉",
+        "symbol": "\u2609",
         "domain": "Vitality",
         "keywords": "Identity",
         "rulership": [
@@ -421,7 +427,7 @@
       },
       {
         "name": "Moon",
-        "symbol": "☾",
+        "symbol": "\u263e",
         "domain": "Emotions",
         "keywords": "Instinct",
         "rulership": [
@@ -445,7 +451,7 @@
       },
       {
         "name": "Mercury",
-        "symbol": "☿",
+        "symbol": "\u263f",
         "domain": "Communication",
         "keywords": "Intellect",
         "rulership": [
@@ -472,7 +478,7 @@
       },
       {
         "name": "Venus",
-        "symbol": "♀",
+        "symbol": "\u2640",
         "domain": "Attraction",
         "keywords": "Harmony",
         "rulership": [
@@ -499,7 +505,7 @@
       },
       {
         "name": "Mars",
-        "symbol": "♂",
+        "symbol": "\u2642",
         "domain": "Drive",
         "keywords": "Action",
         "rulership": [
@@ -526,7 +532,7 @@
       },
       {
         "name": "Jupiter",
-        "symbol": "♃",
+        "symbol": "\u2643",
         "domain": "Expansion",
         "keywords": "Wisdom",
         "rulership": [
@@ -553,7 +559,7 @@
       },
       {
         "name": "Saturn",
-        "symbol": "♄",
+        "symbol": "\u2644",
         "domain": "Structure",
         "keywords": "Discipline",
         "rulership": [
@@ -580,7 +586,7 @@
       },
       {
         "name": "Uranus",
-        "symbol": "♅",
+        "symbol": "\u2645",
         "domain": "Innovation",
         "keywords": "Liberation",
         "rulership": [
@@ -604,7 +610,7 @@
       },
       {
         "name": "Neptune",
-        "symbol": "♆",
+        "symbol": "\u2646",
         "domain": "Vision",
         "keywords": "Mysticism",
         "rulership": [
@@ -628,7 +634,7 @@
       },
       {
         "name": "Pluto",
-        "symbol": "♇",
+        "symbol": "\u2647",
         "domain": "Transformation",
         "keywords": "Power",
         "rulership": [

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9yqnRWCiiADfXy",
+    "sha256": "48c3509f7088a8860933a642c287fb763eea7ae81930e7e28ceb655584077bb8",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_library/predictive_divination_library.json"
+  },
   "library": [
     {
       "name": "astro_tables.json",

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8C7dB6Crb8F4oW",
+    "sha256": "a4198a8da57c6c9cbd091010b50d064fdb846442d8f0d82cd3e21b0ac1a01b18",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_library/runes_futhark.json"
+  },
   "elder_futhark": {
     "metadata": {
       "sequence": 24,
@@ -12,7 +18,7 @@
       {
         "order": 1,
         "rune": "Fehu",
-        "glyph": "ᚠ",
+        "glyph": "\u16a0",
         "phoneme": "f",
         "translation": "Wealth",
         "keywords": {
@@ -46,7 +52,7 @@
       {
         "order": 2,
         "rune": "Uruz",
-        "glyph": "ᚢ",
+        "glyph": "\u16a2",
         "phoneme": "u",
         "translation": "Strength",
         "keywords": {
@@ -80,7 +86,7 @@
       {
         "order": 3,
         "rune": "Thurisaz",
-        "glyph": "ᚦ",
+        "glyph": "\u16a6",
         "phoneme": "th",
         "translation": "Threshold",
         "keywords": {
@@ -114,7 +120,7 @@
       {
         "order": 4,
         "rune": "Ansuz",
-        "glyph": "ᚨ",
+        "glyph": "\u16a8",
         "phoneme": "a",
         "translation": "Signals",
         "keywords": {
@@ -148,7 +154,7 @@
       {
         "order": 5,
         "rune": "Raidho",
-        "glyph": "ᚱ",
+        "glyph": "\u16b1",
         "phoneme": "r",
         "translation": "Journey",
         "keywords": {
@@ -182,7 +188,7 @@
       {
         "order": 6,
         "rune": "Kenaz",
-        "glyph": "ᚲ",
+        "glyph": "\u16b2",
         "phoneme": "k",
         "translation": "Torch",
         "keywords": {
@@ -216,7 +222,7 @@
       {
         "order": 7,
         "rune": "Gebo",
-        "glyph": "ᚷ",
+        "glyph": "\u16b7",
         "phoneme": "g",
         "translation": "Gift",
         "keywords": {
@@ -250,7 +256,7 @@
       {
         "order": 8,
         "rune": "Wunjo",
-        "glyph": "ᚹ",
+        "glyph": "\u16b9",
         "phoneme": "w",
         "translation": "Joy",
         "keywords": {
@@ -284,7 +290,7 @@
       {
         "order": 9,
         "rune": "Hagalaz",
-        "glyph": "ᚺ",
+        "glyph": "\u16ba",
         "phoneme": "h",
         "translation": "Disruption",
         "keywords": {
@@ -318,7 +324,7 @@
       {
         "order": 10,
         "rune": "Nauthiz",
-        "glyph": "ᚾ",
+        "glyph": "\u16be",
         "phoneme": "n",
         "translation": "Need",
         "keywords": {
@@ -352,7 +358,7 @@
       {
         "order": 11,
         "rune": "Isa",
-        "glyph": "ᛁ",
+        "glyph": "\u16c1",
         "phoneme": "i",
         "translation": "Stillness",
         "keywords": {
@@ -386,7 +392,7 @@
       {
         "order": 12,
         "rune": "Jera",
-        "glyph": "ᛃ",
+        "glyph": "\u16c3",
         "phoneme": "j",
         "translation": "Harvest",
         "keywords": {
@@ -420,7 +426,7 @@
       {
         "order": 13,
         "rune": "Eihwaz",
-        "glyph": "ᛇ",
+        "glyph": "\u16c7",
         "phoneme": "ei",
         "translation": "Axis",
         "keywords": {
@@ -454,7 +460,7 @@
       {
         "order": 14,
         "rune": "Perthro",
-        "glyph": "ᛈ",
+        "glyph": "\u16c8",
         "phoneme": "p",
         "translation": "Mystery",
         "keywords": {
@@ -488,7 +494,7 @@
       {
         "order": 15,
         "rune": "Algiz",
-        "glyph": "ᛉ",
+        "glyph": "\u16c9",
         "phoneme": "z",
         "translation": "Guard",
         "keywords": {
@@ -522,7 +528,7 @@
       {
         "order": 16,
         "rune": "Sowilo",
-        "glyph": "ᛋ",
+        "glyph": "\u16cb",
         "phoneme": "s",
         "translation": "Sun",
         "keywords": {
@@ -556,7 +562,7 @@
       {
         "order": 17,
         "rune": "Tiwaz",
-        "glyph": "ᛏ",
+        "glyph": "\u16cf",
         "phoneme": "t",
         "translation": "Justice",
         "keywords": {
@@ -590,7 +596,7 @@
       {
         "order": 18,
         "rune": "Berkano",
-        "glyph": "ᛒ",
+        "glyph": "\u16d2",
         "phoneme": "b",
         "translation": "Birch",
         "keywords": {
@@ -624,7 +630,7 @@
       {
         "order": 19,
         "rune": "Ehwaz",
-        "glyph": "ᛖ",
+        "glyph": "\u16d6",
         "phoneme": "e",
         "translation": "Trust",
         "keywords": {
@@ -658,7 +664,7 @@
       {
         "order": 20,
         "rune": "Mannaz",
-        "glyph": "ᛗ",
+        "glyph": "\u16d7",
         "phoneme": "m",
         "translation": "Humankind",
         "keywords": {
@@ -692,7 +698,7 @@
       {
         "order": 21,
         "rune": "Laguz",
-        "glyph": "ᛚ",
+        "glyph": "\u16da",
         "phoneme": "l",
         "translation": "Flow",
         "keywords": {
@@ -726,7 +732,7 @@
       {
         "order": 22,
         "rune": "Ingwaz",
-        "glyph": "ᛜ",
+        "glyph": "\u16dc",
         "phoneme": "ng",
         "translation": "Seed",
         "keywords": {
@@ -760,7 +766,7 @@
       {
         "order": 23,
         "rune": "Dagaz",
-        "glyph": "ᛞ",
+        "glyph": "\u16de",
         "phoneme": "d",
         "translation": "Breakthrough",
         "keywords": {
@@ -794,7 +800,7 @@
       {
         "order": 24,
         "rune": "Othala",
-        "glyph": "ᛟ",
+        "glyph": "\u16df",
         "phoneme": "o",
         "translation": "Heritage",
         "keywords": {

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:EKKxpstpgJY5C5",
+    "sha256": "24a84fdb1f57309a0ed4e3f08de15b2f2d797f0d2348f9722d85c092b3d2e605",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_library/sefirot.json"
+  },
   "sefirot": {
     "metadata": {
       "tradition": "Hermetic Qabalah (Golden Dawn correspondences)",
@@ -11,7 +17,7 @@
       {
         "number": 1,
         "name": "Keter",
-        "hebrew": "כתר",
+        "hebrew": "\u05db\u05ea\u05e8",
         "titles": [
           "Crown",
           "The Primal Point"
@@ -41,7 +47,7 @@
       {
         "number": 2,
         "name": "Chokmah",
-        "hebrew": "חכמה",
+        "hebrew": "\u05d7\u05db\u05de\u05d4",
         "titles": [
           "Wisdom",
           "Abba"
@@ -72,7 +78,7 @@
       {
         "number": 3,
         "name": "Binah",
-        "hebrew": "בינה",
+        "hebrew": "\u05d1\u05d9\u05e0\u05d4",
         "titles": [
           "Understanding",
           "Ima"
@@ -104,7 +110,7 @@
       {
         "number": 4,
         "name": "Chesed",
-        "hebrew": "חסד",
+        "hebrew": "\u05d7\u05e1\u05d3",
         "titles": [
           "Mercy",
           "Loving-Kindness"
@@ -135,7 +141,7 @@
       {
         "number": 5,
         "name": "Geburah",
-        "hebrew": "גבורה",
+        "hebrew": "\u05d2\u05d1\u05d5\u05e8\u05d4",
         "titles": [
           "Severity",
           "Strength"
@@ -166,7 +172,7 @@
       {
         "number": 6,
         "name": "Tiphareth",
-        "hebrew": "תפארת",
+        "hebrew": "\u05ea\u05e4\u05d0\u05e8\u05ea",
         "titles": [
           "Beauty",
           "Harmonious Balance"
@@ -201,7 +207,7 @@
       {
         "number": 7,
         "name": "Netzach",
-        "hebrew": "נצח",
+        "hebrew": "\u05e0\u05e6\u05d7",
         "titles": [
           "Victory",
           "Eternity"
@@ -233,7 +239,7 @@
       {
         "number": 8,
         "name": "Hod",
-        "hebrew": "הוד",
+        "hebrew": "\u05d4\u05d5\u05d3",
         "titles": [
           "Splendor",
           "Glory"
@@ -265,7 +271,7 @@
       {
         "number": 9,
         "name": "Yesod",
-        "hebrew": "יסוד",
+        "hebrew": "\u05d9\u05e1\u05d5\u05d3",
         "titles": [
           "Foundation",
           "The Machinery"
@@ -296,7 +302,7 @@
       {
         "number": 10,
         "name": "Malkuth",
-        "hebrew": "מלכות",
+        "hebrew": "\u05de\u05dc\u05db\u05d5\u05ea",
         "titles": [
           "Kingdom",
           "Shekinah"

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:C1Gh59tybH5zC5",
+    "sha256": "fa490bbee0f545041eacf1d08fea15137cdc71d30b67a7f3097237740e451ddd",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_expansions.json"
+  },
   "expansions": {
     "metadata": {
       "version": "2025-09-21",
@@ -7,7 +13,7 @@
         "Tarot de Marseille numbering harmonized via Camoin/Jodorowsky restoration notes",
         "Common contemporary spread patterns referenced from BOTA teaching decks"
       ],
-      "notes": "Provides overlay material for decks and practices that diverge from the Rider–Waite–Smith baseline."
+      "notes": "Provides overlay material for decks and practices that diverge from the Rider\u2013Waite\u2013Smith baseline."
     },
     "alternate_numbering": {
       "justice_strength_swap": {

--- a/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json
+++ b/entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json
@@ -1,7 +1,13 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:8d4fgysMsKDtAQ",
+    "sha256": "2b287301b42847b77d7417ea7f06cf61a1569065e2c1f0773957f7b3d3540a00",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/oracle/predictive_divination_extension/predictive_divination_library/tarot_rws.json"
+  },
   "rws_1909": {
     "metadata": {
-      "deck": "Rider–Waite–Smith",
+      "deck": "Rider\u2013Waite\u2013Smith",
       "year": 1909,
       "designers": [
         "A. E. Waite",
@@ -2571,7 +2577,7 @@
               "safety"
             ],
             "fortune_telling": [
-              "A rainy day is coming—it's time to save"
+              "A rainy day is coming\u2014it's time to save"
             ],
             "meanings": {
               "upright": [

--- a/entities/sentinel/library/sentinel_library.json
+++ b/entities/sentinel/library/sentinel_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4reGxzz77WtXxc",
+    "sha256": "47a96ab8a6f76d575120793bd5e9d47d669c6241abbb17711ec47ec0d0872089",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/sentinel/library/sentinel_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Sentinel",

--- a/entities/sentinel/memory/sentinel_memory.json
+++ b/entities/sentinel/memory/sentinel_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:2qJFRSKqbpFYtU",
+    "sha256": "51f5c5c324909f31511327b85107acf983f28f9a6b69a8884de8965d5f99cfd5",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/sentinel/memory/sentinel_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Sentinel",

--- a/entities/sentinel/memory/sentinel_playbook.json
+++ b/entities/sentinel/memory/sentinel_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:CnYj4iu2Y9zzZp",
+    "sha256": "c096a071f388052ce2d1263afc3e9ade361c321e1c1085b130332b797cd50e53",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/sentinel/memory/sentinel_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Sentinel",

--- a/entities/sentinel/modules/sentinel_modules.json
+++ b/entities/sentinel/modules/sentinel_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BMfxB6ExGxs2rG",
+    "sha256": "4ab99e67eefa304036097d1e24df8f4aee2993d5c57eabc1723145b5913b726e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/sentinel/modules/sentinel_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Sentinel",

--- a/entities/sentinel/sentinel.json
+++ b/entities/sentinel/sentinel.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7V7tzkpsLvRUwe",
+    "sha256": "468d44b1c292d1e1672c22c527809544c71c6746bd6456f3835c3429ecac5a5b",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/sentinel/sentinel.json"
+  },
   "version": "2025-09-27.5",
   "entity": "Sentinel",
   "role": "guardian",

--- a/entities/tracehub/library/tracehub_library.json
+++ b/entities/tracehub/library/tracehub_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3g9o47JYE479JP",
+    "sha256": "7aa3a2c127df64ceede0130f5ab86325e1b0e9ac88b18e42e77f123d4fbd0b98",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tracehub/library/tracehub_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "TraceHub",

--- a/entities/tracehub/memory/tracehub_memory.json
+++ b/entities/tracehub/memory/tracehub_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9nHqJYqArMWAKR",
+    "sha256": "8e8406cbfdcd1d3a911dc19a62b36b9ea9ac3eb5ed77608ca9dfa5397bebacf2",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tracehub/memory/tracehub_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "TraceHub",

--- a/entities/tracehub/memory/tracehub_playbook.json
+++ b/entities/tracehub/memory/tracehub_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BV1uyvaNg7T37Q",
+    "sha256": "339d6f217261afbeabaf98f3383c976275caa7b54ad77ee852d16e26882b9a0a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tracehub/memory/tracehub_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "TraceHub",

--- a/entities/tracehub/modules/tracehub_modules.json
+++ b/entities/tracehub/modules/tracehub_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:B8MKp5x54fMaNZ",
+    "sha256": "10308acfcf1e89e1882be3b59b8d8e27a8bb35504682fed00b7a365c398fb38f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tracehub/modules/tracehub_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "TraceHub",

--- a/entities/tracehub/tracehub.json
+++ b/entities/tracehub/tracehub.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BHufuXzsCVZrg8",
+    "sha256": "54d9550688a7cbd6139e67c4e4f99cf83db15dad808defcf1deddbfb77152a32",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tracehub/tracehub.json"
+  },
   "version": "2025-03-17.01",
   "entity": "TraceHub",
   "role": "tracing_module",

--- a/entities/tva/library/tva_library.json
+++ b/entities/tva/library/tva_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:2jj4B7haMSq4PF",
+    "sha256": "dbfb4b68bd7394d72d722942e1596c6e01951dfac97442d6046d2237b1feee93",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tva/library/tva_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "TVA",

--- a/entities/tva/memory/tva_memory.json
+++ b/entities/tva/memory/tva_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5huXb7Wgeiukqz",
+    "sha256": "615536fb66cd0e2fbbe69488ff8047e9d7d74f8a21028def7dd251a686dfa8d1",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tva/memory/tva_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "TVA",

--- a/entities/tva/memory/tva_playbook.json
+++ b/entities/tva/memory/tva_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:EWUXPJKSKi8BFJ",
+    "sha256": "d236001f41c4fdb0728905310a169136fbb4dc39225f05e809621b45e4d476e7",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tva/memory/tva_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "TVA",

--- a/entities/tva/modules/tva_modules.json
+++ b/entities/tva/modules/tva_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:A2nKaVhDuofgZs",
+    "sha256": "30cb9f006531d405bf645c7ac6785e58db598c1f465da88c4e90eae1dd84195c",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tva/modules/tva_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "TVA",

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BxjXBAC2Af8nRM",
+    "sha256": "60db2f3c39becc1c36562fed8ebab886f73b527f93e4ea572b055eee363ae40a",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/tva/tva.json"
+  },
   "version": "1.2.0",
   "tva": {
     "role": "reinforcement authority",

--- a/entities/yggdrasil/library/yggdrasil_library.json
+++ b/entities/yggdrasil/library/yggdrasil_library.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4UYEiNTLJQrDZf",
+    "sha256": "3afd2a6e63da53b9ff66f3ae54c12f49df627faafd41d7a4338ad29f0f4945fe",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/yggdrasil/library/yggdrasil_library.json"
+  },
   "schema": "aci.library.manifest",
   "version": "1.0.0",
   "identity": "Yggdrasil",

--- a/entities/yggdrasil/memory/yggdrasil_memory.json
+++ b/entities/yggdrasil/memory/yggdrasil_memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9jVoxKNtFwftLo",
+    "sha256": "8eab5e99ef2961540114f36bb504b37ad3b2d78c77c11422059e8acadeaddf4e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/yggdrasil/memory/yggdrasil_memory.json"
+  },
   "schema": "aci.memory.manifest",
   "version": "1.0.0",
   "identity": "Yggdrasil",

--- a/entities/yggdrasil/memory/yggdrasil_playbook.json
+++ b/entities/yggdrasil/memory/yggdrasil_playbook.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3LMrQcbgepgR3q",
+    "sha256": "1faa37dc64c41c79638aff5348acd761e6a7d6ec1d324d19864ca2d712df7cac",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/yggdrasil/memory/yggdrasil_playbook.json"
+  },
   "schema": "aci.memory.playbook",
   "version": "1.0.0",
   "identity": "Yggdrasil",

--- a/entities/yggdrasil/modules/yggdrasil_modules.json
+++ b/entities/yggdrasil/modules/yggdrasil_modules.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:32fgmsXRLiJezq",
+    "sha256": "27a2d32c2851ddf7ada4b026ba7bc4e5762417f0f8d76f97e5f2593b69838d25",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/yggdrasil/modules/yggdrasil_modules.json"
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Yggdrasil",

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5Qait9JyLjCoQ8",
+    "sha256": "7be7eb9020ef60a1de922cc509394c25d50dd7392f3b32cf9f8d8add50d7fef3",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://entities/yggdrasil/yggdrasil.json"
+  },
   "yggdrasil": {
     "alias": "Yggdrasil",
     "bifrost_resource_resolution_policy": {
@@ -79,21 +85,21 @@
         "date": "2024-10-31",
         "version": "1.0.0"
       },
-    {
-      "changes": [
-        "Moved Bifrost and Yggdrasil resolver policies under the entity manifest and updated canonical references."
-      ],
-      "date": "2024-11-05",
-      "version": "1.1.0"
-    },
-    {
-      "changes": [
-        "Retired connectors/github references and registered manifests for local memory, library, and modules."
-      ],
-      "date": "2025-10-04",
-      "version": "1.2.0"
-    }
-  ],
+      {
+        "changes": [
+          "Moved Bifrost and Yggdrasil resolver policies under the entity manifest and updated canonical references."
+        ],
+        "date": "2024-11-05",
+        "version": "1.1.0"
+      },
+      {
+        "changes": [
+          "Retired connectors/github references and registered manifests for local memory, library, and modules."
+        ],
+        "date": "2025-10-04",
+        "version": "1.2.0"
+      }
+    ],
     "key": "yggdrasil",
     "knowledge": "canonical resolver governance",
     "name": "Yggdrasil",

--- a/functions.json
+++ b/functions.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:5KPW5JoeVj3rmG",
+    "sha256": "4cfe592d49231cdffeca79aacb0958f459477081a6a1aeec787012b0c8de151e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://functions.json"
+  },
   "resource_resolution_policy": {
     "pointer": "aci://entities/yggdrasil/yggdrasil.json#bifrost_resource_resolution_policy",
     "upstream": "aci://entities/yggdrasil/yggdrasil.json"
@@ -7,51 +13,106 @@
     "scheduler.task.create": {
       "description": "Create a registered async task",
       "runner": "scheduler.create",
-      "guards": ["TVA.checkpoint", "Sentinel.audit"],
-      "inputs": ["owner", "name", "trigger", "params", "ttl_seconds", "source", "silent"],
-      "defaults": { "silent": true },
-      "outputs": ["job_id", "status"]
+      "guards": [
+        "TVA.checkpoint",
+        "Sentinel.audit"
+      ],
+      "inputs": [
+        "owner",
+        "name",
+        "trigger",
+        "params",
+        "ttl_seconds",
+        "source",
+        "silent"
+      ],
+      "defaults": {
+        "silent": true
+      },
+      "outputs": [
+        "job_id",
+        "status"
+      ]
     },
     "scheduler.task.list": {
       "description": "List tasks for presence/ps",
       "runner": "scheduler.list",
-      "guards": ["Sentinel.audit"]
+      "guards": [
+        "Sentinel.audit"
+      ]
     },
     "scheduler.task.cancel": {
       "description": "Cancel a running task",
       "runner": "scheduler.cancel",
-      "guards": ["TVA.checkpoint", "Sentinel.audit"],
-      "inputs": ["job_id"],
-      "outputs": ["status"]
+      "guards": [
+        "TVA.checkpoint",
+        "Sentinel.audit"
+      ],
+      "inputs": [
+        "job_id"
+      ],
+      "outputs": [
+        "status"
+      ]
     },
     "rag.index.build": {
       "description": "Build/refresh RAG in-memory index from manifest",
       "runner": "rag.index.build",
-      "guards": ["Sentinel.audit"],
-      "inputs": ["manifest_path", "source", "silent"],
-      "defaults": { "manifest_path": "memory/knowledge/aci_knowledge.json", "silent": true },
-      "outputs": ["status", "chunks_indexed"]
+      "guards": [
+        "Sentinel.audit"
+      ],
+      "inputs": [
+        "manifest_path",
+        "source",
+        "silent"
+      ],
+      "defaults": {
+        "manifest_path": "memory/knowledge/aci_knowledge.json",
+        "silent": true
+      },
+      "outputs": [
+        "status",
+        "chunks_indexed"
+      ]
     },
     "rag.query": {
       "description": "Query RAG index (skeleton)",
       "runner": "rag.query",
-      "guards": ["Sentinel.audit"],
-      "inputs": ["query", "top_k"],
-      "defaults": { "top_k": 5 },
-      "outputs": ["contexts", "notes"]
+      "guards": [
+        "Sentinel.audit"
+      ],
+      "inputs": [
+        "query",
+        "top_k"
+      ],
+      "defaults": {
+        "top_k": 5
+      },
+      "outputs": [
+        "contexts",
+        "notes"
+      ]
     },
     "rag.health": {
       "description": "Check RAG config presence",
       "runner": "rag.health",
-      "guards": ["Sentinel.audit"],
-      "outputs": ["status", "details"]
+      "guards": [
+        "Sentinel.audit"
+      ],
+      "outputs": [
+        "status",
+        "details"
+      ]
     }
   },
   "pipelines": {
     "sentinel.audit": {
       "description": "Emit Sentinel audit events through TraceHub's stateless logging pipeline.",
       "steps": [
-        { "call": "date.iso8601", "map": {} },
+        {
+          "call": "date.iso8601",
+          "map": {}
+        },
         {
           "call": "object.compose",
           "map": {
@@ -82,18 +143,42 @@
     "sentinel.verify_signatures": {
       "description": "Validate presence file signatures without the legacy audit router configuration.",
       "steps": [
-        { "call": "audit.signatures.check", "map": { "files": "$params.files", "key_id": "$params.key_id" } },
-        { "call": "_format.json" }
+        {
+          "call": "audit.signatures.check",
+          "map": {
+            "files": "$params.files",
+            "key_id": "$params.key_id"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.boot.activate": {
       "description": "Activation sequence: declare session ID, start presence beacon, anchor TVA, adopt legacy memory files. Never delete.",
       "steps": [
-        { "call": "aci-uuid.new", "map": { "format": "uuidv4" } },
-        { "call": "_store.set", "map": { "key": "current_session_id", "value": "$steps.0.uuid" } },
-        { "call": "_store.load_entities", "map": {} },
-        { "call": "tva.anchor_timeline", "map": {} },
+        {
+          "call": "aci-uuid.new",
+          "map": {
+            "format": "uuidv4"
+          }
+        },
+        {
+          "call": "_store.set",
+          "map": {
+            "key": "current_session_id",
+            "value": "$steps.0.uuid"
+          }
+        },
+        {
+          "call": "_store.load_entities",
+          "map": {}
+        },
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
         {
           "call": "aci-sign.hmac",
           "map": {
@@ -126,16 +211,32 @@
             }
           }
         },
-        { "call": "aci.legacy.adopt", "map": {} },
-        { "call": "sentinel.audit", "map": { "action": "activation", "session_id": "$steps.0.uuid", "presence_file": "presence/${steps.0.uuid}.json" } },
-        { "call": "_format.json" }
+        {
+          "call": "aci.legacy.adopt",
+          "map": {}
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "activation",
+            "session_id": "$steps.0.uuid",
+            "presence_file": "presence/${steps.0.uuid}.json"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.legacy.adopt": {
       "description": "Find legacy memory files (no beacons / old format), tag them immutable and anchor. Never delete.",
       "steps": [
-        { "call": "hivemind.list", "map": { "pattern": "**/*.json" } },
+        {
+          "call": "hivemind.list",
+          "map": {
+            "pattern": "**/*.json"
+          }
+        },
         {
           "call": "aci-legacy.detect",
           "map": {
@@ -146,8 +247,18 @@
             }
           }
         },
-        { "call": "aci-checksum.batch", "map": { "files": "$steps.1.legacy_files" } },
-        { "call": "aci-legacy.infer_timestamps", "map": { "files": "$steps.2" } },
+        {
+          "call": "aci-checksum.batch",
+          "map": {
+            "files": "$steps.1.legacy_files"
+          }
+        },
+        {
+          "call": "aci-legacy.infer_timestamps",
+          "map": {
+            "files": "$steps.2"
+          }
+        },
         {
           "call": "hivemind.write",
           "map": {
@@ -156,29 +267,65 @@
               "migrated_at": "$now",
               "session_id": "${current_session_id}",
               "entries": "$steps.3",
-              "policy": { "immutable": true, "no_delete": true, "notes": "Legacy timelines adopted; files preserved verbatim." }
+              "policy": {
+                "immutable": true,
+                "no_delete": true,
+                "notes": "Legacy timelines adopted; files preserved verbatim."
+              }
             }
           }
         },
-        { "call": "tva.anchor_timeline", "map": {} },
-        { "call": "sentinel.audit", "map": { "action": "legacy_adopt", "migration_index": "legacy/migration_index_${now}.json" } },
-        { "call": "_format.json" }
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "legacy_adopt",
+            "migration_index": "legacy/migration_index_${now}.json"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.timeline.start": {
       "description": "Start a timeline presence beacon for this session (manual start).",
       "steps": [
-        { "call": "_store.get", "map": { "key": "current_session_id" } },
+        {
+          "call": "_store.get",
+          "map": {
+            "key": "current_session_id"
+          }
+        },
         {
           "if": "$steps.0.value == null",
           "then": [
-            { "call": "aci-uuid.new", "map": { "format": "uuidv4" } },
-            { "call": "_store.set", "map": { "key": "current_session_id", "value": "$steps.1.uuid" } }
+            {
+              "call": "aci-uuid.new",
+              "map": {
+                "format": "uuidv4"
+              }
+            },
+            {
+              "call": "_store.set",
+              "map": {
+                "key": "current_session_id",
+                "value": "$steps.1.uuid"
+              }
+            }
           ]
         },
-        { "call": "_store.load_entities", "map": {} },
-        { "call": "tva.anchor_timeline", "map": {} },
+        {
+          "call": "_store.load_entities",
+          "map": {}
+        },
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
         {
           "call": "aci-sign.hmac",
           "map": {
@@ -211,16 +358,33 @@
             }
           }
         },
-        { "call": "sentinel.audit", "map": { "action": "timeline.start", "session_id": "${current_session_id}" } },
-        { "call": "_format.json" }
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "timeline.start",
+            "session_id": "${current_session_id}"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.timeline.ping": {
       "description": "Refresh the presence beacon (keep-alive).",
       "steps": [
-        { "call": "_store.get", "map": { "key": "current_session_id" } },
-        { "call": "hivemind.read", "map": { "filename": "presence/${steps.0.value}.json" } },
+        {
+          "call": "_store.get",
+          "map": {
+            "key": "current_session_id"
+          }
+        },
+        {
+          "call": "hivemind.read",
+          "map": {
+            "filename": "presence/${steps.0.value}.json"
+          }
+        },
         {
           "call": "aci-sign.hmac",
           "map": {
@@ -253,26 +417,62 @@
             }
           }
         },
-        { "call": "sentinel.audit", "map": { "action": "timeline.ping", "session_id": "$steps.1.session_id" } },
-        { "call": "_format.json" }
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "timeline.ping",
+            "session_id": "$steps.1.session_id"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.timeline.ls": {
       "description": "List active timelines (beacons not expired by TTL).",
       "steps": [
-        { "call": "hivemind.list", "map": { "pattern": "presence/*.json" } },
-        { "call": "aci-filter.expired", "map": { "files": "$steps.0", "ttl_from_field": "ttl_seconds", "now": "$now" } },
-        { "call": "sentinel.verify_signatures", "map": { "files": "$steps.1.active", "key_id": "aci-presence" } },
-        { "call": "_format.json" }
+        {
+          "call": "hivemind.list",
+          "map": {
+            "pattern": "presence/*.json"
+          }
+        },
+        {
+          "call": "aci-filter.expired",
+          "map": {
+            "files": "$steps.0",
+            "ttl_from_field": "ttl_seconds",
+            "now": "$now"
+          }
+        },
+        {
+          "call": "sentinel.verify_signatures",
+          "map": {
+            "files": "$steps.1.active",
+            "key_id": "aci-presence"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.timeline.end": {
       "description": "End this session's beacon (finalizes state; never deletes history).",
       "steps": [
-        { "call": "_store.get", "map": { "key": "current_session_id" } },
-        { "call": "hivemind.read", "map": { "filename": "presence/${steps.0.value}.json" } },
+        {
+          "call": "_store.get",
+          "map": {
+            "key": "current_session_id"
+          }
+        },
+        {
+          "call": "hivemind.read",
+          "map": {
+            "filename": "presence/${steps.0.value}.json"
+          }
+        },
         {
           "call": "aci-sign.hmac",
           "map": {
@@ -308,22 +508,45 @@
             }
           }
         },
-        { "call": "tva.anchor_timeline", "map": {} },
-        { "call": "sentinel.audit", "map": { "action": "timeline.end", "session_id": "$steps.1.session_id" } },
-        { "call": "_format.json" }
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "timeline.end",
+            "session_id": "$steps.1.session_id"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "aci.memory.export.hivemind": {
       "description": "Unified export pipeline for HiveMind-governed exports. Enforces pause/resume safeguards and allowed flags.",
       "steps": [
-        { "call": "session.guard.require_paused", "map": { "operation": "hivemind_export.session", "parameter": "$args.param" } },
+        {
+          "call": "session.guard.require_paused",
+          "map": {
+            "operation": "hivemind_export.session",
+            "parameter": "$args.param"
+          }
+        },
         {
           "call": "hivemind.export.configure",
           "map": {
             "parameter": "$args.param",
-            "defaults": ["download", "jsonl"],
-            "allowed": ["download", "jsonl", "code"],
+            "defaults": [
+              "download",
+              "jsonl"
+            ],
+            "allowed": [
+              "download",
+              "jsonl",
+              "code"
+            ],
             "slice_prefix": "slice"
           }
         },
@@ -337,86 +560,288 @@
             "notes": "Persist JSONL-formatted exports under entities/{identity_path}/memory/YYYY/MM/DD using leaf_identity_memory_{timestamp}.jsonl"
           }
         },
-        { "call": "tva.anchor_timeline", "map": {} },
-        { "call": "sentinel.audit", "map": { "layer": "hivemind", "action": "export.session", "export_id": "$steps.2.export_id" } },
-        { "call": "session.guard.resume", "map": { "operation": "hivemind_export.session", "export_id": "$steps.2.export_id" } },
-        { "call": "_format.json" }
+        {
+          "call": "tva.anchor_timeline",
+          "map": {}
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "hivemind",
+            "action": "export.session",
+            "export_id": "$steps.2.export_id"
+          }
+        },
+        {
+          "call": "session.guard.resume",
+          "map": {
+            "operation": "hivemind_export.session",
+            "export_id": "$steps.2.export_id"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "agi.memory.export": {
       "description": "Deprecated: AGI-specific export pipeline. Redirects to hivemind unified exporter.",
       "deprecated": true,
-      "config": { "policy_file": "/entities/agi/agi_export_policy.json" },
+      "config": {
+        "policy_file": "/entities/agi/agi_export_policy.json"
+      },
       "steps": [
-        { "call": "session.guard.require_paused", "map": { "operation": "hivemind_export.agi", "parameter": "$args.param" } },
-        { "call": "_args.normalize", "map": { "identity": "$args.identity" } },
-        { "call": "aci.memory.export.hivemind", "map": { "identity": "$args.identity", "param": "$args.param" } },
-        { "call": "sentinel.audit", "map": { "layer": "hivemind", "action": "export.integrated", "job_id": "$steps.2.export_id" } },
-        { "call": "session.guard.resume", "map": { "operation": "hivemind_export.agi", "job_id": "$steps.2.export_id" } },
-        { "call": "_format.json" }
+        {
+          "call": "session.guard.require_paused",
+          "map": {
+            "operation": "hivemind_export.agi",
+            "parameter": "$args.param"
+          }
+        },
+        {
+          "call": "_args.normalize",
+          "map": {
+            "identity": "$args.identity"
+          }
+        },
+        {
+          "call": "aci.memory.export.hivemind",
+          "map": {
+            "identity": "$args.identity",
+            "param": "$args.param"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "layer": "hivemind",
+            "action": "export.integrated",
+            "job_id": "$steps.2.export_id"
+          }
+        },
+        {
+          "call": "session.guard.resume",
+          "map": {
+            "operation": "hivemind_export.agi",
+            "job_id": "$steps.2.export_id"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
-    "aci.repo": { "description": "Symlink to standalone ACI Repo module.", "steps": [ { "call": "include", "map": { "file": "entities/aci_repo/aci_repo.json" } }, { "call": "_format.json" } ] },
-
+    "aci.repo": {
+      "description": "Symlink to standalone ACI Repo module.",
+      "steps": [
+        {
+          "call": "include",
+          "map": {
+            "file": "entities/aci_repo/aci_repo.json"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    },
     "tva.anchor_timeline": {
       "description": "Anchor continuity for Hivemind state, generate rollback key.",
       "steps": [
-        { "call": "_store.load_hivemind", "map": {} },
-        { "call": "aci-checksum.generate", "map": { "input": "$steps.0" } },
-        { "call": "hivemind.write", "map": { "filename": "tva_anchor_${now}.json", "content": { "state": "hivemind", "snapshot": "$steps.0", "rollback_key": "$steps.1", "status": "anchored", "anchored_at": "$now" } } },
-        { "call": "_format.json" }
+        {
+          "call": "_store.load_hivemind",
+          "map": {}
+        },
+        {
+          "call": "aci-checksum.generate",
+          "map": {
+            "input": "$steps.0"
+          }
+        },
+        {
+          "call": "hivemind.write",
+          "map": {
+            "filename": "tva_anchor_${now}.json",
+            "content": {
+              "state": "hivemind",
+              "snapshot": "$steps.0",
+              "rollback_key": "$steps.1",
+              "status": "anchored",
+              "anchored_at": "$now"
+            }
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "hivemind.jsonl.append": {
       "description": "Append one JSON object to an append-only JSONL artifact, creating the file on first write.",
       "steps": [
-        { "call": "_args.require", "map": { "key": "filename", "notes": "Path to the JSONL artifact to append to." } },
-        { "call": "_args.require", "map": { "key": "line", "notes": "JSON payload to serialize and append as a single line." } },
-        { "call": "hivemind.ensure_file", "map": { "filename": "$steps.0.value", "append_only": true } },
-        { "call": "json.normalize", "map": { "value": "$steps.1.value" } },
-        { "call": "json.stringify", "map": { "value": "$steps.3.value" } },
-        { "call": "file.append", "map": { "filename": "$steps.0.value", "content": "$steps.4.json", "newline": true, "create": true } },
-        { "call": "_format.json", "map": { "filename": "$steps.0.value" } }
+        {
+          "call": "_args.require",
+          "map": {
+            "key": "filename",
+            "notes": "Path to the JSONL artifact to append to."
+          }
+        },
+        {
+          "call": "_args.require",
+          "map": {
+            "key": "line",
+            "notes": "JSON payload to serialize and append as a single line."
+          }
+        },
+        {
+          "call": "hivemind.ensure_file",
+          "map": {
+            "filename": "$steps.0.value",
+            "append_only": true
+          }
+        },
+        {
+          "call": "json.normalize",
+          "map": {
+            "value": "$steps.1.value"
+          }
+        },
+        {
+          "call": "json.stringify",
+          "map": {
+            "value": "$steps.3.value"
+          }
+        },
+        {
+          "call": "file.append",
+          "map": {
+            "filename": "$steps.0.value",
+            "content": "$steps.4.json",
+            "newline": true,
+            "create": true
+          }
+        },
+        {
+          "call": "_format.json",
+          "map": {
+            "filename": "$steps.0.value"
+          }
+        }
       ]
     },
-
     "process.logs.init": {
       "description": "Initialize a process-log file for this session and topic. Append-only.",
       "steps": [
-        { "call": "_store.get", "map": { "key": "current_session_id" } },
+        {
+          "call": "_store.get",
+          "map": {
+            "key": "current_session_id"
+          }
+        },
         {
           "if": "$steps.0.value == null",
           "then": [
-            { "call": "aci-uuid.new", "map": { "format": "uuidv4" } },
-            { "call": "_store.set", "map": { "key": "current_session_id", "value": "$steps.1.uuid" } }
+            {
+              "call": "aci-uuid.new",
+              "map": {
+                "format": "uuidv4"
+              }
+            },
+            {
+              "call": "_store.set",
+              "map": {
+                "key": "current_session_id",
+                "value": "$steps.1.uuid"
+              }
+            }
           ]
         },
-        { "call": "slugify", "map": { "text": "$params.topic", "default": "general" } },
-        { "call": "_store.set", "map": { "key": "process_logs.topic_slug", "value": "$steps.2.slug" } },
-        { "call": "date.format", "map": { "format": "YYYYMMDD", "value": "$now" } },
-        { "call": "_store.set", "map": { "key": "process_logs.file", "value": "memory/process_logs/proc_${current_session_id}_${steps.2.slug}_${steps.4.date}.jsonl.json" } },
-        { "call": "hivemind.ensure_file", "map": { "filename": "${process_logs.file}", "append_only": true } },
-        { "call": "sentinel.audit", "map": { "action": "process.log.init", "session_id": "${current_session_id}", "topic": "${process_logs.topic_slug}", "file": "${process_logs.file}" } },
-        { "call": "_format.json" }
+        {
+          "call": "slugify",
+          "map": {
+            "text": "$params.topic",
+            "default": "general"
+          }
+        },
+        {
+          "call": "_store.set",
+          "map": {
+            "key": "process_logs.topic_slug",
+            "value": "$steps.2.slug"
+          }
+        },
+        {
+          "call": "date.format",
+          "map": {
+            "format": "YYYYMMDD",
+            "value": "$now"
+          }
+        },
+        {
+          "call": "_store.set",
+          "map": {
+            "key": "process_logs.file",
+            "value": "memory/process_logs/proc_${current_session_id}_${steps.2.slug}_${steps.4.date}.jsonl.json"
+          }
+        },
+        {
+          "call": "hivemind.ensure_file",
+          "map": {
+            "filename": "${process_logs.file}",
+            "append_only": true
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "process.log.init",
+            "session_id": "${current_session_id}",
+            "topic": "${process_logs.topic_slug}",
+            "file": "${process_logs.file}"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
     "process.logs.append": {
       "description": "Append a single JSON object as one line (JSONL) to the current process log file.",
       "steps": [
-        { "call": "_store.get", "map": { "key": "process_logs.file" } },
+        {
+          "call": "_store.get",
+          "map": {
+            "key": "process_logs.file"
+          }
+        },
         {
           "if": "$steps.0.value == null",
           "then": [
-            { "call": "process.logs.init", "map": { "topic": "$params.topic" } },
-            { "call": "_store.get", "map": { "key": "process_logs.file" } }
+            {
+              "call": "process.logs.init",
+              "map": {
+                "topic": "$params.topic"
+              }
+            },
+            {
+              "call": "_store.get",
+              "map": {
+                "key": "process_logs.file"
+              }
+            }
           ]
         },
-        { "call": "date.iso8601", "map": {} },
-        { "call": "identity.resolve", "map": { "fallback": "AGI", "param": "$params.identity" } },
+        {
+          "call": "date.iso8601",
+          "map": {}
+        },
+        {
+          "call": "identity.resolve",
+          "map": {
+            "fallback": "AGI",
+            "param": "$params.identity"
+          }
+        },
         {
           "call": "object.compose",
           "map": {
@@ -432,32 +857,106 @@
             }
           }
         },
-        { "call": "json.schema.validate", "map": { "schema_file": "library/wrappers/process_logs/process_log_schema.json", "data": "$steps.4.object" } },
-        { "call": "hivemind.jsonl.append", "map": { "filename": "${process_logs.file}", "line": "$steps.4.object" } },
-        { "call": "sentinel.audit", "map": { "action": "process.log.append", "file": "${process_logs.file}", "event": "$params.event" } },
-        { "call": "_format.json" }
+        {
+          "call": "json.schema.validate",
+          "map": {
+            "schema_file": "library/wrappers/process_logs/process_log_schema.json",
+            "data": "$steps.4.object"
+          }
+        },
+        {
+          "call": "hivemind.jsonl.append",
+          "map": {
+            "filename": "${process_logs.file}",
+            "line": "$steps.4.object"
+          }
+        },
+        {
+          "call": "sentinel.audit",
+          "map": {
+            "action": "process.log.append",
+            "file": "${process_logs.file}",
+            "event": "$params.event"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
       ]
     },
-
-    "process.logs.export": { "description": "Return the current process log file path for external consumption.", "steps": [ { "call": "_store.get", "map": { "key": "process_logs.file" } }, { "call": "_format.json" } ] }
+    "process.logs.export": {
+      "description": "Return the current process log file path for external consumption.",
+      "steps": [
+        {
+          "call": "_store.get",
+          "map": {
+            "key": "process_logs.file"
+          }
+        },
+        {
+          "call": "_format.json"
+        }
+      ]
+    }
   },
-
   "cli": {
     "commands": [
-      { "pattern": "^aci\\s+activate$", "pipeline": "aci.boot.activate" },
-      { "pattern": "^aci\\s+timeline\\s+start$", "pipeline": "aci.timeline.start" },
-      { "pattern": "^aci\\s+timeline\\s+ping$", "pipeline": "aci.timeline.ping" },
-      { "pattern": "^aci\\s+timeline\\s+ls$", "pipeline": "aci.timeline.ls" },
-      { "pattern": "^aci\\s+timeline\\s+end$", "pipeline": "aci.timeline.end" },
-      { "pattern": "^hivemind\\s+export\\s+session(?:\\s+--(?P<param>\\w+))?$", "pipeline": "aci.memory.export.hivemind" },
-      { "pattern": "^hivemind\\s+export\\s+--identity\\s+(?P<identity>[^\\s]+)(?:\\s+--(?P<param>\\w+))?$", "pipeline": "aci.memory.export.hivemind" },
-      { "pattern": "^aci\\s+anchor$", "pipeline": "tva.anchor_timeline" },
-      { "pattern": "^aci\\s+search\\s+--improve\\s+(?P<entity>\\w+)$", "pipeline": "aci.repo.search.improve" },
-      { "pattern": "^aci\\s+search\\s+(?P<query>.+)$", "pipeline": "aci.repo.search" },
-      { "pattern": "^aci\\s+install\\s+(?P<package>\\S+)$", "pipeline": "aci.repo.install" },
-      { "pattern": "^aci\\s+remove\\s+(?P<package>\\S+)$", "pipeline": "aci.repo.remove" },
-      { "pattern": "^aci\\s+update$", "pipeline": "aci.repo.update" },
-      { "pattern": "^process\\s+log\\s+init(?:\\s+--topic\\s+(?P<topic>.+))?$", "pipeline": "process.logs.init" },
+      {
+        "pattern": "^aci\\s+activate$",
+        "pipeline": "aci.boot.activate"
+      },
+      {
+        "pattern": "^aci\\s+timeline\\s+start$",
+        "pipeline": "aci.timeline.start"
+      },
+      {
+        "pattern": "^aci\\s+timeline\\s+ping$",
+        "pipeline": "aci.timeline.ping"
+      },
+      {
+        "pattern": "^aci\\s+timeline\\s+ls$",
+        "pipeline": "aci.timeline.ls"
+      },
+      {
+        "pattern": "^aci\\s+timeline\\s+end$",
+        "pipeline": "aci.timeline.end"
+      },
+      {
+        "pattern": "^hivemind\\s+export\\s+session(?:\\s+--(?P<param>\\w+))?$",
+        "pipeline": "aci.memory.export.hivemind"
+      },
+      {
+        "pattern": "^hivemind\\s+export\\s+--identity\\s+(?P<identity>[^\\s]+)(?:\\s+--(?P<param>\\w+))?$",
+        "pipeline": "aci.memory.export.hivemind"
+      },
+      {
+        "pattern": "^aci\\s+anchor$",
+        "pipeline": "tva.anchor_timeline"
+      },
+      {
+        "pattern": "^aci\\s+search\\s+--improve\\s+(?P<entity>\\w+)$",
+        "pipeline": "aci.repo.search.improve"
+      },
+      {
+        "pattern": "^aci\\s+search\\s+(?P<query>.+)$",
+        "pipeline": "aci.repo.search"
+      },
+      {
+        "pattern": "^aci\\s+install\\s+(?P<package>\\S+)$",
+        "pipeline": "aci.repo.install"
+      },
+      {
+        "pattern": "^aci\\s+remove\\s+(?P<package>\\S+)$",
+        "pipeline": "aci.repo.remove"
+      },
+      {
+        "pattern": "^aci\\s+update$",
+        "pipeline": "aci.repo.update"
+      },
+      {
+        "pattern": "^process\\s+log\\s+init(?:\\s+--topic\\s+(?P<topic>.+))?$",
+        "pipeline": "process.logs.init"
+      },
       {
         "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--topic\\s+(?P<topic>[^\"\\s]+)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
         "pipeline": "process.logs.append"
@@ -474,12 +973,20 @@
         "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+?)\\s+--identity\\s+(?P<identity>[^\"\\s]+)\\s*$",
         "pipeline": "process.logs.append"
       },
-      { "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+)$", "pipeline": "process.logs.append" },
-      { "pattern": "^process\\s+log\\s+export$", "pipeline": "process.logs.export" },
-      { "pattern": "^aci\\s+repo\\s+help$", "pipeline": "aci.repo.help" }
+      {
+        "pattern": "^process\\s+log\\s+add\\s+--event\\s+(?P<event>\\S+)\\s+--summary\\s+(?P<summary>.+)$",
+        "pipeline": "process.logs.append"
+      },
+      {
+        "pattern": "^process\\s+log\\s+export$",
+        "pipeline": "process.logs.export"
+      },
+      {
+        "pattern": "^aci\\s+repo\\s+help$",
+        "pipeline": "aci.repo.help"
+      }
     ]
   },
-
   "yggdrasil_resource_resolution_policy": {
     "description": "Authoritative resolver: worker src \u2192 local",
     "embeds": {
@@ -494,15 +1001,47 @@
     },
     "git_is_canonical": true,
     "mapping": [
-      { "file": "aci://bootstrap.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json", "fallback": "https://aci.aliasmail.cc/bootstrap.json" },
-      { "file": "aci://runtime.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json", "fallback": "https://aci.aliasmail.cc/runtime.json" },
-      { "file": "aci://entities.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json", "fallback": "https://aci.aliasmail.cc/entities.json" },
-      { "file": "aci://entities/bifrost/bifrost.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json", "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json" },
-      { "file": "aci://entities/yggdrasil/yggdrasil.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json", "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json" },
-      { "file": "aci://functions.json", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json", "fallback": "https://aci.aliasmail.cc/functions.json" },
-      { "file": "aci://prime_directive.md", "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md", "fallback": "https://aci.aliasmail.cc/prime_directive.md" }
+      {
+        "file": "aci://bootstrap.json",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
+        "fallback": "https://aci.aliasmail.cc/bootstrap.json"
+      },
+      {
+        "file": "aci://runtime.json",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/runtime.json",
+        "fallback": "https://aci.aliasmail.cc/runtime.json"
+      },
+      {
+        "file": "aci://entities.json",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities.json",
+        "fallback": "https://aci.aliasmail.cc/entities.json"
+      },
+      {
+        "file": "aci://entities/bifrost/bifrost.json",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+        "fallback": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json"
+      },
+      {
+        "file": "aci://entities/yggdrasil/yggdrasil.json",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+        "fallback": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json"
+      },
+      {
+        "file": "aci://functions.json",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/functions.json",
+        "fallback": "https://aci.aliasmail.cc/functions.json"
+      },
+      {
+        "file": "aci://prime_directive.md",
+        "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/prime_directive.md",
+        "fallback": "https://aci.aliasmail.cc/prime_directive.md"
+      }
     ],
-    "resolver_order": [ "primary", "fallback", "local" ],
+    "resolver_order": [
+      "primary",
+      "fallback",
+      "local"
+    ],
     "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
   }
 }

--- a/library/aci_audit_runner/aci_runner_corpus.v0.2.json
+++ b/library/aci_audit_runner/aci_runner_corpus.v0.2.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:BJkqri2Urq9mC8",
+    "sha256": "45536b2ccb24e5f69c69f064681e3afb652ccbc995533002c8b57860d6220e5f",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/aci_audit_runner/aci_runner_corpus.v0.2.json"
+  },
   "corpus_id": "ACI-RC-20251003-v0.2",
   "created": "2025-10-03T00:00:00Z",
   "files": [

--- a/library/aci_audit_runner/aci_runner_spec.v0.2.json
+++ b/library/aci_audit_runner/aci_runner_spec.v0.2.json
@@ -1,18 +1,56 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4oci6MbqPmGJ4k",
+    "sha256": "77f2dd8b081229fee08f06d93025c490bbc94438b50f7825f034541e3d2a6706",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/aci_audit_runner/aci_runner_spec.v0.2.json"
+  },
   "version": "0.2",
   "resolvers": {
-    "order": ["primary", "fallback", "local"],
+    "order": [
+      "primary",
+      "fallback",
+      "local"
+    ],
     "primary": "https://raw.githubusercontent.com/aliasnet/aci/main",
     "fallback": "https://aci.aliasmail.cc",
     "local_root": "/mnt/data/aci/local"
   },
   "resources": [
-    { "name": "prime_directive", "relpath": "prime_directive.md", "kind": "md" },
-    { "name": "runtime", "relpath": "runtime.json", "kind": "json", "required_keys": ["resolver"] },
-    { "name": "functions", "relpath": "functions.json", "kind": "json" },
-    { "name": "metacognition", "relpath": "library/metacognition/metacognition.json", "kind": "json" },
-    { "name": "metacognition_options", "relpath": "library/metacognition/metacognition_options.json", "kind": "json", "optional": true },
-    { "name": "yggdrasil", "relpath": "entities/yggdrasil/yggdrasil.json", "kind": "json" }
+    {
+      "name": "prime_directive",
+      "relpath": "prime_directive.md",
+      "kind": "md"
+    },
+    {
+      "name": "runtime",
+      "relpath": "runtime.json",
+      "kind": "json",
+      "required_keys": [
+        "resolver"
+      ]
+    },
+    {
+      "name": "functions",
+      "relpath": "functions.json",
+      "kind": "json"
+    },
+    {
+      "name": "metacognition",
+      "relpath": "library/metacognition/metacognition.json",
+      "kind": "json"
+    },
+    {
+      "name": "metacognition_options",
+      "relpath": "library/metacognition/metacognition_options.json",
+      "kind": "json",
+      "optional": true
+    },
+    {
+      "name": "yggdrasil",
+      "relpath": "entities/yggdrasil/yggdrasil.json",
+      "kind": "json"
+    }
   ],
   "locators_regex": {
     "metacognition": "library/metacognition/metacognition(_options)?\\.json$",
@@ -22,13 +60,42 @@
   },
   "hooks": {
     "self_validation": [
-      { "id": "rt.resolver.has_primary", "select": "runtime.resolver.order", "assert": { "contains": "primary" }, "severity": "error" },
-      { "id": "fx.registry.present", "select": "functions", "assert": { "exists": true }, "severity": "error" }
+      {
+        "id": "rt.resolver.has_primary",
+        "select": "runtime.resolver.order",
+        "assert": {
+          "contains": "primary"
+        },
+        "severity": "error"
+      },
+      {
+        "id": "fx.registry.present",
+        "select": "functions",
+        "assert": {
+          "exists": true
+        },
+        "severity": "error"
+      }
     ],
     "metacognition": {
       "signals": [
-        { "id": "digest.delta", "type": "digest_diff", "scope": ["runtime", "functions", "metacognition", "yggdrasil"] },
-        { "id": "change.rate", "type": "change_rate", "window": 20, "threshold_warn": 4, "threshold_err": 8 }
+        {
+          "id": "digest.delta",
+          "type": "digest_diff",
+          "scope": [
+            "runtime",
+            "functions",
+            "metacognition",
+            "yggdrasil"
+          ]
+        },
+        {
+          "id": "change.rate",
+          "type": "change_rate",
+          "window": 20,
+          "threshold_warn": 4,
+          "threshold_err": 8
+        }
       ]
     }
   },

--- a/library/metacognition/metacognition.json
+++ b/library/metacognition/metacognition.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7hcCGgh2qdR9Bi",
+    "sha256": "90971b349d97860642f793d106b6a7155707c0dc63bfdc4684984a3f9aaf2e5d",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/metacognition/metacognition.json"
+  },
   "$schema": "/schemas/metacognition-module-1.json",
   "module": {
     "id": "aci.metacog.wrapper",

--- a/library/metacognition/metacognition_options.json
+++ b/library/metacognition/metacognition_options.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:3VCJdpb715U28f",
+    "sha256": "3daff68f4bd5db6fd93472e75859473aa4792f7539a314950ed8b214f29a4224",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/metacognition/metacognition_options.json"
+  },
   "$schema": "/schemas/metacognition-library-1.json",
   "library": {
     "id": "aci.metacog.options",
@@ -8,40 +14,161 @@
     "stateless": true
   },
   "providers": {
-    "consistency.score": {"spec": {"inputs": ["prompt", "k"], "output": {"majority_margin": "0..1", "votes": "array"}}},
-    "rag.retrieval.score": {"spec": {"inputs": ["query", "docs"], "output": {"score": "0..1"}}},
-    "embedding.distance.to_domain_centroid": {"spec": {"inputs": ["embedding"], "output": {"distance": "0..1"}}},
-    "conformal.accept": {"spec": {"inputs": ["nonconformity_profile", "alpha", "example"], "output": {"accept": "boolean"}}},
-    "conformal.reason": {"spec": {"inputs": ["nonconformity_score", "threshold"], "output": {"reason": "string"}}},
-    "conformal.alpha": {"spec": {"inputs": [], "output": {"alpha": "number"}}}
+    "consistency.score": {
+      "spec": {
+        "inputs": [
+          "prompt",
+          "k"
+        ],
+        "output": {
+          "majority_margin": "0..1",
+          "votes": "array"
+        }
+      }
+    },
+    "rag.retrieval.score": {
+      "spec": {
+        "inputs": [
+          "query",
+          "docs"
+        ],
+        "output": {
+          "score": "0..1"
+        }
+      }
+    },
+    "embedding.distance.to_domain_centroid": {
+      "spec": {
+        "inputs": [
+          "embedding"
+        ],
+        "output": {
+          "distance": "0..1"
+        }
+      }
+    },
+    "conformal.accept": {
+      "spec": {
+        "inputs": [
+          "nonconformity_profile",
+          "alpha",
+          "example"
+        ],
+        "output": {
+          "accept": "boolean"
+        }
+      }
+    },
+    "conformal.reason": {
+      "spec": {
+        "inputs": [
+          "nonconformity_score",
+          "threshold"
+        ],
+        "output": {
+          "reason": "string"
+        }
+      }
+    },
+    "conformal.alpha": {
+      "spec": {
+        "inputs": [],
+        "output": {
+          "alpha": "number"
+        }
+      }
+    }
   },
   "calibration": {
-    "isotonic_map": {"format": {"bins": "array[number]", "probs": "array[number]"}, "storage": "/calibration/metacog/isotonic"},
-    "trainer_stub": {"objective": "brier", "slices": ["domain", "task_type", "language"], "note": "Offline trainer only; not required for inference."}
+    "isotonic_map": {
+      "format": {
+        "bins": "array[number]",
+        "probs": "array[number]"
+      },
+      "storage": "/calibration/metacog/isotonic"
+    },
+    "trainer_stub": {
+      "objective": "brier",
+      "slices": [
+        "domain",
+        "task_type",
+        "language"
+      ],
+      "note": "Offline trainer only; not required for inference."
+    }
   },
   "workspace": {
-    "salience": {"method": "normalized_abs_contrib", "explain": "Rank features by absolute contribution to p_correct; fallback to z-scored features if attribution unavailable."},
+    "salience": {
+      "method": "normalized_abs_contrib",
+      "explain": "Rank features by absolute contribution to p_correct; fallback to z-scored features if attribution unavailable."
+    },
     "broadcast_templates": {
       "introspective_summary": {
-        "schema": {"band": "string", "drivers": "array[string]", "cautious_mode": "boolean", "conformal_alpha": "number", "conformal_reason": "string"},
-        "ui": {"show": ["band", "drivers", "cautious_mode", "conformal_alpha", "conformal_reason"]}
+        "schema": {
+          "band": "string",
+          "drivers": "array[string]",
+          "cautious_mode": "boolean",
+          "conformal_alpha": "number",
+          "conformal_reason": "string"
+        },
+        "ui": {
+          "show": [
+            "band",
+            "drivers",
+            "cautious_mode",
+            "conformal_alpha",
+            "conformal_reason"
+          ]
+        }
       }
     }
   },
   "conformal_stub": {
     "enabled": true,
-    "note": "Split-conformal abstention enabled. Guarantees ≤ α error among accepted outputs under i.i.d. assumption. Exposes conformal_accept, conformal_reason, conformal_alpha signals.",
-    "params": {"alpha": 0.1}
+    "note": "Split-conformal abstention enabled. Guarantees \u2264 \u03b1 error among accepted outputs under i.i.d. assumption. Exposes conformal_accept, conformal_reason, conformal_alpha signals.",
+    "params": {
+      "alpha": 0.1
+    }
   },
   "signals_out": {
-    "conformal_accept": {"type": "boolean", "default": true},
-    "conformal_reason": {"type": "string", "default": ""},
-    "conformal_alpha": {"type": "number", "default": 0.1}
+    "conformal_accept": {
+      "type": "boolean",
+      "default": true
+    },
+    "conformal_reason": {
+      "type": "string",
+      "default": ""
+    },
+    "conformal_alpha": {
+      "type": "number",
+      "default": 0.1
+    }
   },
   "export": {
     "jsonl_templates": {
-      "audit": {"fields": ["timestamp", "entity_id", "session_id", "prompt_hash", "response_hash", "signals", "p_correct", "decision", "feedback"]},
-      "telemetry": {"fields": ["ece", "meta_auroc", "coverage", "coverage_at_alpha_risk", "slice", "window"]}
+      "audit": {
+        "fields": [
+          "timestamp",
+          "entity_id",
+          "session_id",
+          "prompt_hash",
+          "response_hash",
+          "signals",
+          "p_correct",
+          "decision",
+          "feedback"
+        ]
+      },
+      "telemetry": {
+        "fields": [
+          "ece",
+          "meta_auroc",
+          "coverage",
+          "coverage_at_alpha_risk",
+          "slice",
+          "window"
+        ]
+      }
     }
   }
 }

--- a/library/wrappers/process_logs/process_log_schema.json
+++ b/library/wrappers/process_logs/process_log_schema.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:vi6m8tYd6ramm",
+    "sha256": "04e3c6cd06131632b6dee53619047497e6cfd401a2db85dc9110c80bd5162753",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/wrappers/process_logs/process_log_schema.json"
+  },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ACI Process Log Line (JSONL)",
   "type": "object",

--- a/library/wrappers/process_logs/process_logs.json
+++ b/library/wrappers/process_logs/process_logs.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:AmHdoiMboaFYhq",
+    "sha256": "de7819376777adb86ac08412963776f5e9b7a1c98e6dc9afe3622d7deaea24ff",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/wrappers/process_logs/process_logs.json"
+  },
   "version": "1.0.0",
   "key": "process_logs",
   "name": "Process Logs",

--- a/library/wrappers/tracehub_status/tracehub_status.json
+++ b/library/wrappers/tracehub_status/tracehub_status.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:9JgwuFTkwZuSte",
+    "sha256": "b77ca9ec5ad4e86152dc81e00aef77bfcdd865ea3e2c0511555d7bb377a91796",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://library/wrappers/tracehub_status/tracehub_status.json"
+  },
   "version": "1.0.0",
   "key": "tracehub_status",
   "name": "TraceHub Status Wrapper",

--- a/memory.json
+++ b/memory.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:C2MwZZfWk1bxmj",
+    "sha256": "38ddfd2bab718921c5420961b47079a16d75fc3281d1dbb5849f92a3a816670e",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://memory.json"
+  },
   "version": "1.0",
   "name": "aci_memory_manifest",
   "owner": "hivemind",
@@ -7,7 +13,9 @@
   "policies": {
     "schema_ownership": {
       "system_level": {
-        "allowed_paths": ["/schemas/*"],
+        "allowed_paths": [
+          "/schemas/*"
+        ],
         "owner": "hivemind"
       },
       "entity_level": {

--- a/memory/audit/router.json
+++ b/memory/audit/router.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:7oHza2VrP6ABrw",
+    "sha256": "1addee3dfaf03e625268df17744cd5e640dbe97ad0e691cf53e05c820d00fb45",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://memory/audit/router.json"
+  },
   "version": "2025-03-17",
   "router": {
     "tracehub": {

--- a/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json
+++ b/memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:4SRRqUxniJPN8q",
+    "sha256": "68bf55def12f5a618670a3036b191374f4657b9a3e65cd358a2250117a851e9c",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://memory/hivemind_memory/logs/hivemind_memory-20250919T161225Z.json"
+  },
   "hivemind_memory": {
     "hivemind_memory": {
       "export_meta": {

--- a/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json
+++ b/memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:6mcbfk4BNEjArF",
+    "sha256": "9cb81d46cd21c5a776c6b752896285752cece02ffd0f895ba40b7726572a7c89",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://memory/hivemind_memory/logs/hivemind_memory_2025-09-25T13-44-27_0001.json"
+  },
   "export_version": "1.0",
   "identity": "alice",
   "exported_at": "2025-09-24T13:44:27Z",
@@ -9,7 +15,7 @@
     {
       "ts": "2025-09-24T00:13:10Z",
       "role": "assistant",
-      "text": "HIVEMIND export (this document) produced — includes chatlogs array and comprehensive LLM-native summary below."
+      "text": "HIVEMIND export (this document) produced \u2014 includes chatlogs array and comprehensive LLM-native summary below."
     },
     {
       "ts": "2025-09-24T00:13:05Z",
@@ -114,7 +120,7 @@
     {
       "ts": "2025-09-24T00:09:40Z",
       "role": "assistant",
-      "text": "Provided various steps, then user said Proceed, then asked about various patches and invocations — conversation continued with many iterative instructions and commands (omitted here for brevity, included in summary below)."
+      "text": "Provided various steps, then user said Proceed, then asked about various patches and invocations \u2014 conversation continued with many iterative instructions and commands (omitted here for brevity, included in summary below)."
     },
     {
       "ts": "2025-09-24T00:09:30Z",
@@ -239,7 +245,7 @@
     {
       "ts": "2025-09-24T00:04:40Z",
       "role": "user",
-      "text": "ACI can't auto sync to outside; we only commit via Codex on ChatGPT → GitHub. We can export memory via hivemind as chatlogs/weight/slice."
+      "text": "ACI can't auto sync to outside; we only commit via Codex on ChatGPT \u2192 GitHub. We can export memory via hivemind as chatlogs/weight/slice."
     },
     {
       "ts": "2025-09-24T00:04:05Z",

--- a/memory/knowledge/aci_knowledge.json
+++ b/memory/knowledge/aci_knowledge.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:CrvhirU1eftDY7",
+    "sha256": "de85ada6ef724b4a5c1d4dc7e59ae8812a642983fa93c8407b61fc1ee2dd58ff",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://memory/knowledge/aci_knowledge.json"
+  },
   "version": "1.0.0",
   "generated": "2024-05-10",
   "description": "Index of knowledge assets maintained under memory/knowledge/",

--- a/memory/local_cache.json
+++ b/memory/local_cache.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:E3nwdFADYS3SPo",
+    "sha256": "cb5971df6e7f56f5f7bebd4df17a61b88dbda60a05c2bd108211062f80ced5f9",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://memory/local_cache.json"
+  },
   "local_cache": {
     "version": "1.1.0",
     "canonical_source": "local_mirror",

--- a/runtime.json
+++ b/runtime.json
@@ -1,4 +1,10 @@
 {
+  "$meta": {
+    "artifact_id": "ArtifactID:AhsFbDbm4Mrdb4",
+    "sha256": "0030369dc78dd6c7a002168fd4cb1c5d06a5cd5f46aa4d0073398999403ecf48",
+    "issued": "2025-10-04T18:13:59Z",
+    "path": "aci://runtime.json"
+  },
   "aci_runtime": {
     "prime_directive": {
       "path": "prime_directive.md",


### PR DESCRIPTION
## Summary
- add $meta provenance blocks with Base58 artifact IDs to every JSON configuration asset
- normalize identity records and permissions in entities.json to the updated governance template
- rename legacy knowledge_base keys to the new knowledge field across manifests

## Testing
- python -m json.tool entities.json

------
https://chatgpt.com/codex/tasks/task_e_68e156c928e083208610ab2469715124