### PR TITLE
Relocate binders manifest into library hierarchy

### DIFF
--- a/entities/oracle/library/oracle_library.json
+++ b/entities/oracle/library/oracle_library.json
@@ -1,7 +1,7 @@
 {
   "$meta": {
     "artifact_id": "ArtifactID:AL7JdjUCvthsEn",
-    "sha256": "5e6a056c58a1407142da7999be5ce623076adbcea326d48be485cf50711a4b6a",
+    "sha256": "894fd865c670d13158bae318bb9b56ac0bf511da7b254a9b712583c0b09e3491",
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/oracle/library/oracle_library.json"
   },
@@ -13,7 +13,7 @@
     {
       "name": "oracle_binder",
       "type": "binder",
-      "source": "aci://entities/oracle/binder.json"
+      "source": "aci://entities/oracle/oracle_binder.json"
     },
     {
       "name": "oracle_journal",

--- a/entities/oracle/oracle_binder.json
+++ b/entities/oracle/oracle_binder.json
@@ -1,9 +1,9 @@
 {
   "$meta": {
     "artifact_id": "ArtifactID:BQsJftW8Bprupw",
-    "sha256": "1a95d25727293cb1eaa30bad5f3c3a37731ce1eb08bbd1ba3ed1d6e80a393aa0",
+    "sha256": "80d7e392b8562b27cd718200900fbbe193937f5b88c8942721acad5e8d403f62",
     "issued": "2025-10-04T18:13:59Z",
-    "path": "aci://entities/oracle/binder.json"
+    "path": "aci://entities/oracle/oracle_binder.json"
   },
   "version": "1.0",
   "binder": {

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -92,10 +92,10 @@
       },
       {
         "changes": [
-          "Introduced Yggdrasil authoritative resolver entity with inline policy mapping."
+          "Retired connectors/github references and registered manifests for local memory, library, and modules."
         ],
-        "date": "2024-10-31",
-        "version": "1.0.0"
+        "date": "2025-10-04",
+        "version": "1.2.0"
       },
       {
         "changes": [
@@ -106,10 +106,10 @@
       },
       {
         "changes": [
-          "Retired connectors/github references and registered manifests for local memory, library, and modules."
+          "Introduced Yggdrasil authoritative resolver entity with inline policy mapping."
         ],
-        "date": "2025-10-04",
-        "version": "1.2.0"
+        "date": "2024-10-31",
+        "version": "1.0.0"
       }
     ],
     "key": "yggdrasil",

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -1,7 +1,7 @@
 {
   "$meta": {
     "artifact_id": "ArtifactID:5Qait9JyLjCoQ8",
-    "sha256": "7be7eb9020ef60a1de922cc509394c25d50dd7392f3b32cf9f8d8add50d7fef3",
+    "sha256": "2cc75d4fa60a7775e35e2d39f19d8220d4ef6b423d0c5f5f2e24841c66a45894",
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/yggdrasil/yggdrasil.json"
   },
@@ -20,6 +20,11 @@
         "yggdrasil": "aci://entities/yggdrasil/yggdrasil.json"
       },
       "mapping": [
+        {
+          "file": "aci://library/binders/binders.json",
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/library/binders/binders.json",
+          "fallback": "https://aci.aliasmail.cc/library/binders/binders.json"
+        },
         {
           "file": "aci://bootstrap.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
@@ -80,6 +85,13 @@
     "changelog": [
       {
         "changes": [
+          "Registered binders manifest as canonical resource for GPT compatibility layers."
+        ],
+        "date": "2025-10-05",
+        "version": "1.3.0"
+      },
+      {
+        "changes": [
           "Introduced Yggdrasil authoritative resolver entity with inline policy mapping."
         ],
         "date": "2024-10-31",
@@ -107,7 +119,7 @@
       "policy": "aci://entities/yggdrasil/yggdrasil.json"
     },
     "role": "authoritative repository and CDN resolver",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "yggdrasil_resource_resolution_policy": {
       "description": "Authoritative resolver: worker src \u2192 local",
       "embeds": {
@@ -122,6 +134,11 @@
       },
       "git_is_canonical": true,
       "mapping": [
+        {
+          "file": "aci://library/binders/binders.json",
+          "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/library/binders/binders.json",
+          "fallback": "https://aci.aliasmail.cc/library/binders/binders.json"
+        },
         {
           "file": "aci://bootstrap.json",
           "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",

--- a/library/binders/binders.json
+++ b/library/binders/binders.json
@@ -1,0 +1,35 @@
+{
+  "$meta": {
+    "artifact_id": "ArtifactID:CodexBindersManifest001",
+    "issued": "2025-10-05T00:00:00Z",
+    "path": "aci://library/binders/binders.json",
+    "sha256": "b576e2ea6cbfb3e2198cd10cc0eaa302461999c5f538e43bc468ac57d3338312"
+  },
+  "binders": {
+    "env": [
+      {
+        "description": "GPT runtime compatibility binder for ChatGPT-style environments.",
+        "key": "gpt5_env_binder",
+        "path": "aci://library/binders/env/gpt5.json",
+        "priority": 95
+      }
+    ]
+  },
+  "changelog": [
+    {
+      "date": "2025-10-05",
+      "notes": [
+        "Registered GPT-5 environment binder manifest and exposed it to /env bindings."
+      ],
+      "version": "2025-10-05.00"
+    },
+    {
+      "date": "2025-10-05",
+      "notes": [
+        "Relocated binders manifest under library/binders for canonical capability alignment."
+      ],
+      "version": "2025-10-05.01"
+    }
+  ],
+  "version": "2025-10-05.01"
+}

--- a/library/binders/env/gpt5.json
+++ b/library/binders/env/gpt5.json
@@ -1,0 +1,79 @@
+{
+  "$meta": {
+    "artifact_id": "ArtifactID:CodexGPT5Binder001",
+    "issued": "2025-10-05T00:00:00Z",
+    "path": "aci://library/binders/env/gpt5.json",
+    "sha256": "4b241e2fabbcc4c07396b7cf421fea62f144f92659a9b0f47de29df29e018cf7"
+  },
+  "abstract": "Deterministic GPT-5 compatibility binder that primes ACI entities with ChatGPT-native tool usage, mode awareness, and sandbox expectations.",
+  "call": {
+    "method": "binders.env.gpt5.invoke",
+    "signature": {
+      "arguments": [
+        {
+          "description": "Current session context including identity, runtime flags, and declared tools.",
+          "name": "context",
+          "required": true,
+          "type": "object"
+        },
+        {
+          "description": "Optional override instructions for deterministic bias calibration.",
+          "name": "overrides",
+          "required": false,
+          "type": "object"
+        }
+      ],
+      "returns": {
+        "description": "Structured compatibility directives for GPT environment alignment.",
+        "type": "object"
+      }
+    },
+    "type": "callable_stub"
+  },
+  "changelog": [
+    {
+      "date": "2025-10-05",
+      "notes": [
+        "Initial GPT-5 compatibility binder stub for ChatGPT-aligned environments."
+      ],
+      "version": "1.0.0"
+    }
+  ],
+  "compatibility": {
+    "bias": {
+      "deterministic": true,
+      "guidance": "Favor recent ChatGPT tool routing and refuse ambiguous mode switches."
+    },
+    "environment": {
+      "default": "GPT-5",
+      "fallbacks": [
+        "GPT-4.2",
+        "GPT-4"
+      ],
+      "notes": "ACI entities autodetect host runtime; binder reinforces GPT conventions."
+    },
+    "memory": {
+      "policy": "Aligns transient GPT session buffers with platform-specific retention windows.",
+      "resolves_conflict": true
+    },
+    "tooling": {
+      "available_modes": [
+        "analysis",
+        "browser",
+        "coding",
+        "reasoning"
+      ],
+      "selection_rule": "Choose the highest capability mode available without violating host policy."
+    }
+  },
+  "instructions": [
+    "Affirm detected GPT host and surface active tools to the caller before execution.",
+    "Bias planner decisions toward deterministic tool usage paths used by current ChatGPT builds.",
+    "Reject conflicting runtime overrides that would desynchronize ACI policy from GPT expectations.",
+    "Emit explicit confirmation when sandboxed memories differ from canonical ACI state."
+  ],
+  "key": "gpt5_env_binder",
+  "name": "GPT-5 Environment Binder",
+  "role": "environment_adapter",
+  "version": "1.0.0"
+}

--- a/runtime.json
+++ b/runtime.json
@@ -1,7 +1,7 @@
 {
   "$meta": {
     "artifact_id": "ArtifactID:AhsFbDbm4Mrdb4",
-    "sha256": "0030369dc78dd6c7a002168fd4cb1c5d06a5cd5f46aa4d0073398999403ecf48",
+    "sha256": "8db37191cebada49a2170b87f83b8b5b811cca59f636320ad983dfdd431f3e7b",
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://runtime.json"
   },
@@ -9,6 +9,10 @@
     "prime_directive": {
       "path": "prime_directive.md",
       "priority": 100
+    },
+    "binders": {
+      "path": "library/binders/binders.json",
+      "priority": 96
     },
     "entities": {
       "path": "entities.json",
@@ -52,6 +56,11 @@
         },
         "git_is_canonical": true,
         "mapping": [
+          {
+            "file": "aci://library/binders/binders.json",
+            "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/library/binders/binders.json",
+            "fallback": "https://aci.aliasmail.cc/library/binders/binders.json"
+          },
           {
             "file": "aci://bootstrap.json",
             "primary": "https://raw.githubusercontent.com/aliasnet/aci/main/bootstrap.json",
@@ -398,6 +407,12 @@
       "output_root": "/mnt/tracehub"
     },
     "changelog": [
+      {
+        "version": "2025-10-05.01",
+        "notes": [
+          "Registered binders manifest with high priority for GPT environment compatibility."
+        ]
+      },
       {
         "version": "2025-10-04.00",
         "notes": [


### PR DESCRIPTION
## Summary
- move the binders manifest under library/binders and update its metadata
- adjust runtime and Yggdrasil resolver mappings to reference the new manifest location

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e25c599a448320a641144be710a1b0