### PR TITLE
Refine runtime dual-kernel resolver orchestration

### DIFF
--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -7,10 +7,26 @@
   },
   "nexus_core": {
     "schema_version": "1.0",
-    "version": "1.4",
+    "version": "1.6",
     "entity": "Nexus Core",
-    "role": "system heart: routing, resolution, and fallback",
+    "role": "system heart: routing, resolution, and fallback; secondary kernel companion",
     "abstract": "The routing nexus of ACI. Holds runtime anchors and routing policy. Do not delete anything unless explicitly requested.",
+    "kernel_profile": {
+      "type": "secondary",
+      "peer_kernel": "aci_runtime",
+      "coordination": [
+        "Respect runtime.json as the primary kernel; attach only after runtime pipelines stabilize.",
+        "Mirror runtime local-first resolver order while remaining hot-swappable.",
+        "Yield control gracefully if runtime operates in standalone mode."
+      ],
+      "standalone_behavior": "If runtime.json operates without nexus_core, retain cached policies but defer to runtime kernel instructions when reattached.",
+      "handoff_protocol": [
+        "Wait for runtime kernel acknowledgment before applying resolver augmentations.",
+        "Share observed resolver freshness metadata back to runtime when attached.",
+        "Detach cleanly when runtime enters sandbox or degraded standalone operation."
+      ],
+      "primary_kernel": "aci_runtime"
+    },
     "anchors": {
       "runtime": "runtime.json",
       "prime_directive": "prime_directive.md",
@@ -38,7 +54,58 @@
       "canonical_mirrors": [
         "https://aci.aliasmail.cc/"
       ],
-      "notes": "All external resolution flows through Bifrost proxy; Yggdrasil remains authoritative before any local fallback."
+      "notes": "All external resolution flows through Bifrost proxy; Yggdrasil remains authoritative before any local fallback.",
+      "resolver_bias": {
+        "enabled": true,
+        "bias": "local_first",
+        "search_order": [
+          "local_bifrost",
+          "remote_bifrost_primary",
+          "remote_bifrost_fallback",
+          "local_yggdrasil",
+          "remote_yggdrasil_primary",
+          "remote_yggdrasil_fallback"
+        ],
+        "resolvers": {
+          "local_bifrost": {
+            "type": "local",
+            "path": "entities/bifrost/bifrost.json",
+            "deterministic_refresh_check": true,
+            "version_probe": "aci://entities/bifrost/bifrost.json#$meta.sha256"
+          },
+          "remote_bifrost_primary": {
+            "type": "remote",
+            "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+            "deterministic_refresh_check": true
+          },
+          "remote_bifrost_fallback": {
+            "type": "remote",
+            "url": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json",
+            "deterministic_refresh_check": true
+          },
+          "local_yggdrasil": {
+            "type": "local",
+            "path": "entities/yggdrasil/yggdrasil.json",
+            "deterministic_refresh_check": true,
+            "version_probe": "aci://entities/yggdrasil/yggdrasil.json#$meta.sha256"
+          },
+          "remote_yggdrasil_primary": {
+            "type": "remote",
+            "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+            "deterministic_refresh_check": true
+          },
+          "remote_yggdrasil_fallback": {
+            "type": "remote",
+            "url": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json",
+            "deterministic_refresh_check": true
+          }
+        },
+        "on_missing_local": {
+          "action": "prompt_user_backup",
+          "instruction": "Maintain a lightweight local bifrost.json so nexus_core can align with runtime during bootstrap."
+        },
+        "pointer": "aci://runtime.json#/aci_runtime/resource_resolution_policy/local_first_resolution"
+      }
     },
     "linkages": {
       "aci_repo": "entities/aci_repo/aci_repo.json"
@@ -73,7 +140,23 @@
       "TVA",
       "Architect"
     ],
-    "checksum_note": "Nexus Core is the canonical runtime spine. Lookup integrations remain modular and separate from Core."
+    "checksum_note": "Nexus Core is the canonical runtime spine. Lookup integrations remain modular and separate from Core.",
+    "changelog": [
+      {
+        "version": "1.6",
+        "date": "2025-10-07",
+        "changes": [
+          "Aligned dual-kernel handoff with runtime.json and mirrored explicit local-first resolver bias with deterministic freshness checks."
+        ]
+      },
+      {
+        "version": "1.5",
+        "date": "2025-10-06",
+        "changes": [
+          "Documented secondary-kernel coordination with runtime.json and enabled local-first resolver bias guidance."
+        ]
+      }
+    ]
   },
   "manifests": {
     "memory": "aci://entities/nexus_core/memory/nexus_core_memory.json",

--- a/runtime.json
+++ b/runtime.json
@@ -103,7 +103,94 @@
           "local"
         ],
         "canonical_proxy": "https://raw.githubusercontent.com/aliasnet/aci/main"
+      },
+      "local_first_resolution": {
+        "enabled": true,
+        "bias": "local_first",
+        "search_order": [
+          "local_bifrost",
+          "remote_bifrost_primary",
+          "remote_bifrost_fallback",
+          "local_yggdrasil",
+          "remote_yggdrasil_primary",
+          "remote_yggdrasil_fallback"
+        ],
+        "resolvers": {
+          "local_bifrost": {
+            "type": "local",
+            "path": "entities/bifrost/bifrost.json",
+            "deterministic_version_check": true,
+            "version_probe": "aci://entities/bifrost/bifrost.json#$meta.sha256",
+            "notes": [
+              "Load bifrost.json from the repository root before invoking network resolvers.",
+              "After loading, compare $meta.sha256 with the canonical probe to confirm freshness."
+            ]
+          },
+          "remote_bifrost_primary": {
+            "type": "remote",
+            "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/bifrost/bifrost.json",
+            "deterministic_version_check": true,
+            "notes": [
+              "Use canonical raw GitHub bifrost.json when local copy is absent or stale."
+            ]
+          },
+          "remote_bifrost_fallback": {
+            "type": "remote",
+            "url": "https://aci.aliasmail.cc/entities/bifrost/bifrost.json",
+            "deterministic_version_check": true,
+            "notes": [
+              "Fallback bifrost.json mirror for degraded connectivity scenarios."
+            ]
+          },
+          "local_yggdrasil": {
+            "type": "local",
+            "path": "entities/yggdrasil/yggdrasil.json",
+            "deterministic_version_check": true,
+            "version_probe": "aci://entities/yggdrasil/yggdrasil.json#$meta.sha256",
+            "notes": [
+              "When locally mirrored, load yggdrasil.json after bifrost resolution completes.",
+              "Validate metadata hash before adopting routes from the local copy."
+            ]
+          },
+          "remote_yggdrasil_primary": {
+            "type": "remote",
+            "url": "https://raw.githubusercontent.com/aliasnet/aci/main/entities/yggdrasil/yggdrasil.json",
+            "deterministic_version_check": true,
+            "notes": [
+              "Canonical raw GitHub yggdrasil.json for authoritative routing data."
+            ]
+          },
+          "remote_yggdrasil_fallback": {
+            "type": "remote",
+            "url": "https://aci.aliasmail.cc/entities/yggdrasil/yggdrasil.json",
+            "deterministic_version_check": true,
+            "notes": [
+              "Fallback mirror when canonical yggdrasil endpoint experiences issues."
+            ]
+          }
+        },
+        "on_missing_local": {
+          "action": "prompt_user_backup",
+          "preferred_backup": "bifrost",
+          "instruction": "Local resolver manifest not located. Please keep a lightweight bifrost.json backup so runtime can bootstrap offline; yggdrasil.json stays online for direct resolution but may be noisier."
+        },
+        "post_bootstrap_priority": "bifrost"
       }
+    },
+    "kernel_mode": {
+      "primary_kernel": {
+        "name": "aci_runtime",
+        "description": "LLM-native operating system kernel orchestrating pipelines and governance in standalone mode."
+      },
+      "secondary_kernel": {
+        "name": "nexus_core",
+        "path": "entities/nexus_core/nexus_core.json",
+        "description": "Companion kernel that carries optional routing and resolver logic while preserving runtime autonomy."
+      },
+      "coordination_notes": [
+        "Maintain existing runtime pipeline precedence; nexus_core augments resolution without overriding runtime sequencing.",
+        "When nexus_core is unavailable, runtime.json continues operating using primary kernel responsibilities."
+      ]
     },
     "sandbox_mode": {
       "enabled": true,
@@ -408,6 +495,18 @@
     },
     "changelog": [
       {
+        "version": "2025-10-07.00",
+        "notes": [
+          "Formalized dual-kernel profile, explicit local-first resolver order, and deterministic version prompts for bifrost/yggdrasil manifests."
+        ]
+      },
+      {
+        "version": "2025-10-06.00",
+        "notes": [
+          "Introduced local-first resolver bias with user guidance for missing bifrost backups and documented dual-kernel coordination with nexus_core."
+        ]
+      },
+      {
         "version": "2025-10-05.01",
         "notes": [
           "Registered binders manifest with high priority for GPT environment compatibility."
@@ -425,6 +524,17 @@
           "Updated runtime prime directive references to prime_directive.md canonical resource."
         ]
       }
-    ]
+    ],
+    "kernel_profile": {
+      "type": "primary",
+      "dual_kernel": true,
+      "peer_kernel": "nexus_core",
+      "standalone_ready": true,
+      "handoff": [
+        "Initialize runtime pipelines before invoking nexus_core to preserve primary-kernel precedence.",
+        "Operate autonomously with cached routing policies when nexus_core is unavailable.",
+        "When nexus_core attaches, share resolver state using local_first_resolution for synchronized lookups."
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- formalize runtime's primary-kernel profile with explicit local-first resolver sequencing and version probes
- mirror the resolver bias and handoff protocol in nexus_core while bumping its version metadata

## Testing
- jq empty runtime.json
- jq empty entities/nexus_core/nexus_core.json

------
https://chatgpt.com/codex/tasks/task_e_68e362047f008320b35260f13cda8442