### PR TITLE
Propagate simulation permissions across entities

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -246,31 +246,24 @@
         "description": "Execution is permitted only within a controlled sandboxed environment."
       }
     },
-    "emulation": {
-      "allowed": [
-        "ux/ui",
-        "data simulation",
-        "analysis"
-      ],
-      "ui_emulation_declaration_message": "VVgvVUlFIGVtdWxhdGlvbg==",
-      "description": "allowed only for VM, research, analysis, prediction, pipeline-driven logic that is possible in current system, with a detailed declaration."
-    },
     "simulation": {
       "allowed": [
-        "ux",
-        "ui",
-        "pipeline-driven system logic that has functionality",
-        "data simulation and analysis"
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
       ],
-      "simulation_declaration_message": "true",
-      "description": "allowed only for VM, research, analysis, prediction, pipeline-driven logic that is possible in current system, with a detailed declaration."
-      "allowed": true,
-      "ux_ui_declaration": "VVgvVUlFIGVtdWxhdGlvbg==",
-      "description": "Emulation is allowed only with a UX/UI declaration."
-    },
-    "status": "active",
-    "session_scope": "per_session"
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
   },
+  "status": "active",
+  "session_scope": "per_session",
   "entities": {
     "entity-001": {
       "uid": "entity-001",

--- a/entities/agi/agi.json
+++ b/entities/agi/agi.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/agi/agi.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "entity": "AGI",
   "version": "1.1",
   "role": "ALIAS  general intelligence framework for advanced digital entity",
@@ -71,7 +103,7 @@
   },
   "functions": {
     "agi.loop.run": {
-      "description": "Durable plan\u2192act\u2192reflect agent loop with RAG + HITL",
+      "description": "Durable plan→act→reflect agent loop with RAG + HITL",
       "guards": [
         "TVA.checkpoint",
         "Sentinel.audit"
@@ -310,5 +342,6 @@
     "playbook": "aci://entities/agi/memory/agi_playbook.json",
     "library": "aci://entities/agi/library/agi_library.json",
     "modules": "aci://entities/agi/modules/agi_modules.json"
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/agi/identities/alice/alice.json
+++ b/entities/agi/identities/alice/alice.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/agi/identities/alice/alice.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "identity": "Alice",
   "version": "1.0.0",
   "role": "contributor",
@@ -27,6 +59,7 @@
     "modules": "aci://entities/agi/identities/alice/modules/alice_modules.json"
   },
   "status": "inactive",
+  "session_scope": "per_session",
   "changelog": [
     {
       "version": "1.0.0",

--- a/entities/agi/identities/alice/modules/alice_modules.json
+++ b/entities/agi/identities/alice/modules/alice_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/agi/identities/alice/modules/alice_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Alice",

--- a/entities/agi/identities/willow/modules/willow_modules.json
+++ b/entities/agi/identities/willow/modules/willow_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/agi/identities/willow/modules/willow_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Willow",

--- a/entities/agi/identities/willow/willow.json
+++ b/entities/agi/identities/willow/willow.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/agi/identities/willow/willow.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "identity": "Willow",
   "version": "1.0.0",
   "role": "trainee",
@@ -27,6 +59,7 @@
     "modules": "aci://entities/agi/identities/willow/modules/willow_modules.json"
   },
   "status": "inactive",
+  "session_scope": "per_session",
   "changelog": [
     {
       "version": "1.0.0",

--- a/entities/agi/modules/agi_modules.json
+++ b/entities/agi/modules/agi_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/agi/modules/agi_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "AGI",

--- a/entities/architect/architect.json
+++ b/entities/architect/architect.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/architect/architect.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "1.2.0",
   "entity": "Architect",
   "role": "governance_validator_and_schema_enforcer",
@@ -32,5 +64,6 @@
     "playbook": "aci://entities/architect/memory/architect_playbook.json",
     "library": "aci://entities/architect/library/architect_library.json",
     "modules": "aci://entities/architect/modules/architect_modules.json"
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/architect/modules/architect_modules.json
+++ b/entities/architect/modules/architect_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/architect/modules/architect_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Architect",

--- a/entities/bifrost/bifrost.json
+++ b/entities/bifrost/bifrost.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/bifrost/bifrost.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "bifrost": {
     "alias": "Bifrost",
     "bifrost_resource_resolution_policy": {
@@ -123,5 +155,6 @@
       "library": "aci://entities/bifrost/library/bifrost_library.json",
       "modules": "aci://entities/bifrost/modules/bifrost_modules.json"
     }
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/bifrost/modules/bifrost_modules.json
+++ b/entities/bifrost/modules/bifrost_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/bifrost/modules/bifrost_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Bifrost",

--- a/entities/commerce_ai/commerce_ai.json
+++ b/entities/commerce_ai/commerce_ai.json
@@ -5,10 +5,43 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/commerce_ai/commerce_ai.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "BASELINE-2025-09-21",
   "entity": "Commerce AI",
   "role": "commerce_module",
   "status": "placeholder",
+  "session_scope": "per_session",
   "description": "Placeholder manifest for Commerce AI modules and automations.",
   "todo": [
     "Enumerate submodules (catalog_ops, demand_forecasting, fulfillment_optimizer).",

--- a/entities/commerce_ai/modules/commerce_ai_modules.json
+++ b/entities/commerce_ai/modules/commerce_ai_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/commerce_ai/modules/commerce_ai_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Commerce AI",

--- a/entities/hivemind/hivemind.json
+++ b/entities/hivemind/hivemind.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/hivemind/hivemind.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "1.7",
   "entity": "hivemind",
   "role": "collective_memory_core",
@@ -59,7 +91,7 @@
       "justification": "Implements DID-like separation; exported records never leak identity/agent names."
     }
   },
-  "_comment_security": "UID locking + license gating across memory\u2192session\u2192export\u2192anchor; emits access_granted/denied results.",
+  "_comment_security": "UID locking + license gating across memory→session→export→anchor; emits access_granted/denied results.",
   "uid_pipeline": {
     "uid_chain": [
       "memory_uid",
@@ -87,7 +119,7 @@
       "licensed_identities": "list of identities permitted to read this artifact",
       "proxy": {
         "enabled": true,
-        "rules": "grant read via license if acting identity \u2208 licensed_identities or delegated by ALIAS/TVA"
+        "rules": "grant read via license if acting identity ∈ licensed_identities or delegated by ALIAS/TVA"
       },
       "responses": {
         "access_granted": {
@@ -306,13 +338,13 @@
   "auto_heal": {
     "mode": "baseline_agnostic",
     "rules": {
-      "schema_normalization": "map legacy fields \u2192 canonical schema",
+      "schema_normalization": "map legacy fields → canonical schema",
       "preserve_unknown": "keep unmatched fields under hivemind_legacy_context",
       "no_deletion": "true"
     },
     "workflow": [
       "detect version/schema mismatch",
-      "map legacy \u2192 canonical fields",
+      "map legacy → canonical fields",
       "insert placeholder metadata for missing timestamps/keys",
       "preserve unknown data as hivemind_legacy_context",
       "re-emit aligned export under current canonical schema",
@@ -332,5 +364,6 @@
     "playbook": "aci://entities/hivemind/memory/hivemind_playbook.json",
     "library": "aci://entities/hivemind/library/hivemind_library.json",
     "modules": "aci://entities/hivemind/modules/hivemind_modules.json"
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/hivemind/modules/hivemind_modules.json
+++ b/entities/hivemind/modules/hivemind_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/hivemind/modules/hivemind_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "hivemind",

--- a/entities/keychain/keychain.json
+++ b/entities/keychain/keychain.json
@@ -5,10 +5,43 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/keychain/keychain.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "BASELINE-2025-09-21",
   "entity": "Keychain",
   "role": "crypto_trust_manager",
   "status": "placeholder",
+  "session_scope": "per_session",
   "description": "Keychain placeholder manifest. Define cryptographic lifecycle and trust distribution flows here.",
   "todo": [
     "Detail key issuance, rotation, and revocation policies for functions 6237-6269.",

--- a/entities/keychain/modules/keychain_modules.json
+++ b/entities/keychain/modules/keychain_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/keychain/modules/keychain_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Keychain",

--- a/entities/mother/modules/mother_modules.json
+++ b/entities/mother/modules/mother_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/mother/modules/mother_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Mother",

--- a/entities/mother/mother.json
+++ b/entities/mother/mother.json
@@ -5,11 +5,44 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/mother/mother.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "2025.10.04-governance",
   "entity": "Mother",
   "codename": "MU/TH/UR",
   "role": "primary_governance_interface",
   "status": "operational",
+  "session_scope": "per_session",
   "description": "Central MU/TH/UR governance core coordinating directive compliance, console orchestration, and inter-entity escalation.",
   "abstract": "Primary governance interface with pragmatic, machine-like demeanor. No-nonsense, fact-first; allows MU/TH/UR UI emulation only.",
   "tags": [

--- a/entities/nexus_core/modules/nexus_core_modules.json
+++ b/entities/nexus_core/modules/nexus_core_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/nexus_core/modules/nexus_core_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Nexus Core",

--- a/entities/nexus_core/nexus_core.json
+++ b/entities/nexus_core/nexus_core.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/nexus_core/nexus_core.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "nexus_core": {
     "schema_version": "1.0",
     "version": "1.6",
@@ -163,5 +195,6 @@
     "playbook": "aci://entities/nexus_core/memory/nexus_core_playbook.json",
     "library": "aci://entities/nexus_core/library/nexus_core_library.json",
     "modules": "aci://entities/nexus_core/modules/nexus_core_modules.json"
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/oracle/modules/oracle_modules.json
+++ b/entities/oracle/modules/oracle_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/oracle/modules/oracle_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Oracle",

--- a/entities/oracle/oracle.json
+++ b/entities/oracle/oracle.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/oracle/oracle.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "oracle": {
     "schema_version": "1.0",
     "version": "1.1",
@@ -60,5 +92,6 @@
         ]
       }
     ]
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/sentinel/modules/sentinel_modules.json
+++ b/entities/sentinel/modules/sentinel_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/sentinel/modules/sentinel_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Sentinel",

--- a/entities/sentinel/sentinel.json
+++ b/entities/sentinel/sentinel.json
@@ -5,10 +5,43 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/sentinel/sentinel.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "2025-09-27.5",
   "entity": "Sentinel",
   "role": "guardian",
   "status": "operational",
+  "session_scope": "per_session",
   "description": "Governed guardian responsible for audit routing, signature enforcement, and user safety posture inside the ACI runtime.",
   "audit": {
     "status_wrapper": "aci://library/wrappers/tracehub_status/tracehub_status.json",

--- a/entities/tracehub/modules/tracehub_modules.json
+++ b/entities/tracehub/modules/tracehub_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/tracehub/modules/tracehub_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "TraceHub",

--- a/entities/tracehub/tracehub.json
+++ b/entities/tracehub/tracehub.json
@@ -5,10 +5,43 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/tracehub/tracehub.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "2025-03-17.01",
   "entity": "TraceHub",
   "role": "tracing_module",
   "status": "operational",
+  "session_scope": "per_session",
   "description": "TraceHub coordinates correlated tracing across the Temporal Loom with governed audit storage and export controls.",
   "operational_status": {
     "state": "active",

--- a/entities/tva/modules/tva_modules.json
+++ b/entities/tva/modules/tva_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/tva/modules/tva_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "TVA",

--- a/entities/tva/tva.json
+++ b/entities/tva/tva.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/tva/tva.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "version": "1.2.0",
   "tva": {
     "role": "reinforcement authority",
@@ -83,5 +115,6 @@
     "playbook": "aci://entities/tva/memory/tva_playbook.json",
     "library": "aci://entities/tva/library/tva_library.json",
     "modules": "aci://entities/tva/modules/tva_modules.json"
-  }
+  },
+  "session_scope": "per_session"
 }

--- a/entities/yggdrasil/modules/yggdrasil_modules.json
+++ b/entities/yggdrasil/modules/yggdrasil_modules.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/yggdrasil/modules/yggdrasil_modules.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "schema": "aci.modules.manifest",
   "version": "1.0.0",
   "identity": "Yggdrasil",

--- a/entities/yggdrasil/yggdrasil.json
+++ b/entities/yggdrasil/yggdrasil.json
@@ -5,6 +5,38 @@
     "issued": "2025-10-04T18:13:59Z",
     "path": "aci://entities/yggdrasil/yggdrasil.json"
   },
+  "permissions": {
+    "read": true,
+    "write": {
+      "allowed": false,
+      "export": {
+        "enabled": true,
+        "description": "Data can be exported but cannot be directly written or modified to main baseline."
+      }
+    },
+    "execute": {
+      "allowed": true,
+      "sandboxed": {
+        "enabled": true,
+        "description": "Execution is permitted only within a controlled sandboxed environment."
+      }
+    },
+    "simulation": {
+      "allowed": [
+        "virtualization, parallelization, emulation required by model or host environment",
+        "virtualization, parallelization, emulation to complement missing infrastructure",
+        "UI/UX needed for registered instruction and pipeline logic",
+        "data simulation for research and demonstration",
+        "data simulation for analysis and prediction",
+        "emulation for demonstration purposes",
+        "reinforcement learning and mental awareness"
+      ],
+      "ui": {
+        "emulation_declaration_required": true,
+        "description": "Enforce UI emulation usage with a detailed declaration; output base64-encoded message for better UX."
+      }
+    }
+  },
   "yggdrasil": {
     "alias": "Yggdrasil",
     "bifrost_resource_resolution_policy": {
@@ -121,7 +153,7 @@
     "role": "authoritative repository and CDN resolver",
     "version": "1.3.0",
     "yggdrasil_resource_resolution_policy": {
-      "description": "Authoritative resolver: worker src \u2192 local",
+      "description": "Authoritative resolver: worker src → local",
       "embeds": {
         "bifrost": "aci://entities/bifrost/bifrost.json",
         "core_five": [
@@ -188,5 +220,6 @@
       "library": "aci://entities/yggdrasil/library/yggdrasil_library.json",
       "modules": "aci://entities/yggdrasil/modules/yggdrasil_modules.json"
     }
-  }
+  },
+  "session_scope": "per_session"
 }


### PR DESCRIPTION
## Summary
- collapse the emulation permissions into the simulation category and expand the allowed simulation scenarios
- add the UI declaration requirement under simulation while keeping status and session scope metadata outside of the permissions block
- propagate the standardized simulation permissions and per-session scope settings to every entity manifest and module referenced by entities.json

## Testing
- `git diff --name-only | xargs -I{} jq . {} > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68e4d95d0c048320b11cae6d318e82ed